### PR TITLE
Make Device Access compile on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_FULL_
 
 link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 link_directories(${Boost_LIBRARY_DIRS})
-target_link_libraries( ${PROJECT_NAME}  ${LibXML++_LDFLAGS} -Wl,$<IF:$<CXX_COMPILER_ID:Clang>,-all_load,--whole-archive> ${libexception} ${libfileparser} ${libutil}  -Wl,$<IF:$<CXX_COMPILER_ID:Clang>,-noall_load,--no-whole-archive> ${Boost_LIBRARIES} ${LibXML++_LIBRARIES} ${glib_LIBRARIES} pthread dl)
+target_link_libraries( ${PROJECT_NAME}  ${LibXML++_LDFLAGS} -Wl,$<$<CXX_COMPILER_ID:Clang>:-all_load>$<$<NOT:$<CXX_COMPILER_ID:Clang>>:--whole-archive> ${libexception} ${libfileparser} ${libutil}  -Wl,$<$<CXX_COMPILER_ID:Clang>:-noall_load>$<$<NOT:$<CXX_COMPILER_ID:Clang>>:--no-whole-archive> ${Boost_LIBRARIES} ${LibXML++_LIBRARIES} ${glib_LIBRARIES} pthread dl)
 
 #The make coverage command is only available in debug mode
   IF(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${${PROJECT_NAME}_FULL_
 
 link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 link_directories(${Boost_LIBRARY_DIRS})
-target_link_libraries( ${PROJECT_NAME}  -Wl,--whole-archive ${libexception} ${libfileparser} ${libutil}  -Wl,--no-whole-archive ${Boost_LIBRARIES} ${LibXML++_LIBRARIES} ${glib_LIBRARIES} pthread dl) 
+target_link_libraries( ${PROJECT_NAME}  ${LibXML++_LDFLAGS} -Wl,$<IF:$<CXX_COMPILER_ID:Clang>,-all_load,--whole-archive> ${libexception} ${libfileparser} ${libutil}  -Wl,$<IF:$<CXX_COMPILER_ID:Clang>,-noall_load,--no-whole-archive> ${Boost_LIBRARIES} ${LibXML++_LIBRARIES} ${glib_LIBRARIES} pthread dl)
 
 #The make coverage command is only available in debug mode
   IF(CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ get_property(inc_dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIR
 
 # The PCIe backend can only be built on Linux, so we define a variable here that
 # we can then use in other places.
-if(PLATFORM_ID STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
   set(HAVE_PCIE_BACKEND 1)
   add_definitions(-DCHIMERATK_HAVE_PCIE_BACKEND)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,15 @@ include_directories("${PROJECT_BINARY_DIR}/generated_include")
 # Only these include directories should be copied for examples. 
 get_property(inc_dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
 
+# The PCIe backend can only be built on Linux, so we define a variable here that
+# we can then use in other places.
+if(PLATFORM_ID STREQUAL "Linux")
+  set(HAVE_PCIE_BACKEND 1)
+  add_definitions(-DCHIMERATK_HAVE_PCIE_BACKEND)
+else()
+  set(HAVE_PCIE_BACKEND 0)
+endif()
+
 # Now add other includes; headers added after this point will  not be copied as
 # part of the installation
 include_directories(${Boost_INCLUDE_DIRS} ${glib_INCLUDE_DIRS} ${LibXML++_INCLUDE_DIRS})

--- a/device_backends/CMakeLists.txt
+++ b/device_backends/CMakeLists.txt
@@ -2,12 +2,12 @@ set(SOURCE
    ${SOURCE}
    ${CMAKE_CURRENT_SOURCE_DIR}/src/DeviceBackend.cc
    ${CMAKE_CURRENT_SOURCE_DIR}/src/DeviceBackendImpl.cc
-   ${CMAKE_CURRENT_SOURCE_DIR}/src/PcieBackend.cc
+   $<${HAVE_PCIE_BACKEND}:${CMAKE_CURRENT_SOURCE_DIR}/src/PcieBackend.cc>
    ${CMAKE_CURRENT_SOURCE_DIR}/src/NumericAddressedBackend.cc
    ${CMAKE_CURRENT_SOURCE_DIR}/src/NumericAddressedBackendRegisterAccessor.cc
    ${CMAKE_CURRENT_SOURCE_DIR}/src/DummyBackend.cc
    ${CMAKE_CURRENT_SOURCE_DIR}/src/LogicalNameMappingBackend.cc
-   ${CMAKE_CURRENT_SOURCE_DIR}/src/PcieBackendException.cc
+   $<${HAVE_PCIE_BACKEND}:${CMAKE_CURRENT_SOURCE_DIR}/src/PcieBackendException.cc>
    ${CMAKE_CURRENT_SOURCE_DIR}/src/BackendFactory.cc
    ${CMAKE_CURRENT_SOURCE_DIR}/src/RebotBackend.cc
    ${CMAKE_CURRENT_SOURCE_DIR}/src/TcpCtrl.cc
@@ -29,10 +29,10 @@ set(HEADERS
    ${CMAKE_CURRENT_SOURCE_DIR}/include/LNMBackendChannelAccessor.h
    ${CMAKE_CURRENT_SOURCE_DIR}/include/LNMBackendVariableAccessor.h
    ${CMAKE_CURRENT_SOURCE_DIR}/include/BackendFactory.h
-   ${CMAKE_CURRENT_SOURCE_DIR}/include/PcieBackend.h
+   $<${HAVE_PCIE_BACKEND}:${CMAKE_CURRENT_SOURCE_DIR}/include/PcieBackend.h>
    ${CMAKE_CURRENT_SOURCE_DIR}/include/LogicalNameMappingBackend.h
    ${CMAKE_CURRENT_SOURCE_DIR}/include/DummyBackend.h
-   ${CMAKE_CURRENT_SOURCE_DIR}/include/PcieBackendException.h
+   $<${HAVE_PCIE_BACKEND}:${CMAKE_CURRENT_SOURCE_DIR}/include/PcieBackendException.h>
    ${CMAKE_CURRENT_SOURCE_DIR}/include/llrfdrv_io_compat.h
    ${CMAKE_CURRENT_SOURCE_DIR}/include/pciedev_io.h
    ${CMAKE_CURRENT_SOURCE_DIR}/include/pcieuni_io_compat.h

--- a/device_backends/src/BackendFactory.cc
+++ b/device_backends/src/BackendFactory.cc
@@ -11,7 +11,9 @@
 #include "BackendFactory.h"
 #include "MapFileParser.h"
 #include "RebotBackend.h"
+#ifdef CHIMERATK_HAVE_PCIE_BACKEND
 #include "PcieBackend.h"
+#endif
 #include "DummyBackend.h"
 #include "LogicalNameMappingBackend.h"
 #include "DMapFileParser.h"
@@ -57,8 +59,10 @@ namespace ChimeraTK {
   }
 
   BackendFactory::BackendFactory(){
+#ifdef CHIMERATK_HAVE_PCIE_BACKEND
     registerBackendType("pci","",&PcieBackend::createInstance, CHIMERATK_DEVICEACCESS_VERSION);
     registerBackendType("pci","pcie",&PcieBackend::createInstance, CHIMERATK_DEVICEACCESS_VERSION);
+#endif
     registerBackendType("dummy","",&DummyBackend::createInstance, CHIMERATK_DEVICEACCESS_VERSION);
     registerBackendType("rebot","",&RebotBackend::createInstance, CHIMERATK_DEVICEACCESS_VERSION);
     registerBackendType("logicalNameMap","",&LogicalNameMappingBackend::createInstance, CHIMERATK_DEVICEACCESS_VERSION);

--- a/examples/custom_backend_registration/CMakeLists.txt
+++ b/examples/custom_backend_registration/CMakeLists.txt
@@ -10,6 +10,7 @@ foreach( SOURCE_FILE ${LIBRARY_SOURCE_FILES} )
   get_filename_component(TARGET ${SOURCE_FILE} NAME_WE)
 #  link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
   add_library(${TARGET} SHARED ${SOURCE_FILE})
+  target_link_libraries(${TARGET} ${PROJECT_NAME})
 endforeach()
 
 #cpp files are the source for tests

--- a/fileparsers/src/parserUtilities.cc
+++ b/fileparsers/src/parserUtilities.cc
@@ -1,4 +1,5 @@
 #include <stdexcept>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include "parserUtilities.h"
@@ -13,7 +14,7 @@ namespace mtca4u{
     static std::string appendForwardSlash(const std::string& path);
     
     std::string getCurrentWorkingDirectory() {
-      char* currentWorkingDir = get_current_dir_name();
+      char* currentWorkingDir = getcwd(nullptr, 0);
       if (currentWorkingDir == nullptr) {
         throw std::runtime_error("Could not get the current working directory");
       }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,11 +21,13 @@ aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR}/executables_src testExecutables
 foreach( testExecutableSrcFile ${testExecutables})
   #NAME_WE means the base name without path and (longest) extension
   get_filename_component(executableName ${testExecutableSrcFile} NAME_WE)
-  add_executable(${executableName} ${testExecutableSrcFile})
-  # ATTENTION: Do not link against the boost_unit_test_library! Doing so would require #defining BOOST_TEST_DYN_LINK and some
-  # other quirks. If not done, strange crashes occur on newer boost/gcc versions!
-  target_link_libraries(${executableName} ${PROJECT_NAME} ${PROJECT_NAME}_TEST_LIBRARY)
-  add_test(${executableName} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${executableName})
+  if (HAVE_PCIE_BACKEND OR NOT(executableName STREQUAL "testDevice" OR executableName STREQUAL "testMtca4uDeviceAccess" OR executableName STREQUAL "testPcieBackend"))
+    add_executable(${executableName} ${testExecutableSrcFile})
+    # ATTENTION: Do not link against the boost_unit_test_library! Doing so would require #defining BOOST_TEST_DYN_LINK and some
+    # other quirks. If not done, strange crashes occur on newer boost/gcc versions!
+    target_link_libraries(${executableName} ${PROJECT_NAME} ${PROJECT_NAME}_TEST_LIBRARY)
+    add_test(${executableName} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${executableName})
+  endif()
 endforeach(testExecutableSrcFile)
 
 #

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,4 +130,5 @@ foreach( backendTestLibSrcFile ${backendTestLibSources})
   #NAME_WE means the base name without path and (longest) extension
   get_filename_component(libName ${backendTestLibSrcFile} NAME_WE)
   add_library(${libName} SHARED ${backendTestLibSrcFile})
+  target_link_libraries(${libName} ${PROJECT_NAME})
 endforeach()


### PR DESCRIPTION
In the original version the Device Access library does not compile on macOS. This is a pity, because the Control System Adapter depends on this library and there are a number of scenarios where using the code makes sense on non-Linux systems.

The problems that appear when compiling on macOS can be put in two categories: problems caused by using LLVM instead of GCC and problems caused by different APIs (BSD vs Linux). This PR addresses both kind of issues.

In order to make the build work on macOS, the call to the Linux-specific `get_current_dir_name` function has been replaced with a call to the `getcwd` function, which works on both platforms. The PCIe backend and tests that depend on it are only built on Linux because there is no reasonable way how it could be ported to other platforms. Finally, a few linker flags have been changed.

I have verified that with the changes the code still builds on Linux (Ubuntu 16.04 LTS).