### PR TITLE
Make dummy backend thread safe.

### DIFF
--- a/device_backends/include/DummyBackend.h
+++ b/device_backends/include/DummyBackend.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <list>
 #include <set>
+#include <mutex>
 
 #include <boost/function.hpp>
 
@@ -95,6 +96,7 @@ namespace ChimeraTK {
       std::set< uint64_t > _readOnlyAddresses;
       std::multimap< AddressRange, boost::function<void(void)> > _writeCallbackFunctions;
       RegisterInfoMapPointer _registerMapping;
+      std::mutex mutex;
 
       void resizeBarContents();
       std::map< uint8_t, size_t > getBarSizesInBytesFromRegisterMapping() const;


### PR DESCRIPTION
The dummy backend did not use any synchronization mechanism when reading and writing. This meant that devices backed by the device backend could show strange behavior when accessing them from multiple threads.

This patch introduces a mutex that is acquired for all read and write operations. The mutex is not acquired when attaching callbacks or setting address ranges as read only, as those functionality is specific to the dummy backend and thus not exposed by the `Device` class.