### PR TITLE
Avoid name collision of "label" types (issue #19).

### DIFF
--- a/tests/executables_src/testSharedDummyBackend.cpp
+++ b/tests/executables_src/testSharedDummyBackend.cpp
@@ -1,7 +1,6 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE SharedDummyBackendTest
 #include <boost/test/unit_test.hpp>
-using namespace boost::unit_test_framework;
 
 #include <sys/file.h>
 
@@ -20,7 +19,10 @@ using namespace boost::unit_test_framework;
 #include <algorithm>
 #include <utility>
 
+namespace {
+
 using namespace ChimeraTK;
+using namespace boost::unit_test_framework;
 
 // Use a file lock on shareddummyTest.dmap to ensure we are not running concurrent tests in parallel using the same
 // shared dummies.
@@ -115,6 +117,8 @@ BOOST_AUTO_TEST_CASE( testReadWrite ) {
     BOOST_CHECK((std::vector<int>)processVarsWrite21 == (std::vector<int>)processVarsRead);
     dev.close();
 }
+
+} // anonymous namespace
 
 /*********************************************************************************************************************/
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/unitTestsNotUnderCtest/testSharedDummyBackendExt.cpp
+++ b/tests/unitTestsNotUnderCtest/testSharedDummyBackendExt.cpp
@@ -1,7 +1,6 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE SharedDummyBackendTest
 #include <boost/test/unit_test.hpp>
-using namespace boost::unit_test_framework;
 
 #include "Device.h"
 #include "Utilities.h"
@@ -19,7 +18,10 @@ using namespace boost::unit_test_framework;
 #include <chrono>
 #include <utility>
 
+namespace {
+
 using namespace ChimeraTK;
+using namespace boost::unit_test_framework;
 
 // Static function prototypes
 static void interrupt_handler(int);
@@ -281,3 +283,4 @@ static bool shm_exists(std::string shmName){
   return result;
 }
 
+} // anonymous namespace


### PR DESCRIPTION
This PR fixes the name collision discussed in #19.