### PR TITLE
Read any group from pointers

### DIFF
--- a/device/include/ReadAnyGroup.h
+++ b/device/include/ReadAnyGroup.h
@@ -25,6 +25,7 @@ namespace ChimeraTK {
       /** Construct finalised group with the given elements. The group will behave like finalise() had already been
        *  called. */
       ReadAnyGroup(std::initializer_list<TransferElementAbstractor> list);
+      ReadAnyGroup(std::initializer_list<boost::shared_ptr<TransferElement>> list);
 
       template<typename ITERATOR>
       ReadAnyGroup(ITERATOR first, ITERATOR last);
@@ -35,6 +36,7 @@ namespace ChimeraTK {
        *
        *  The register must be must be readable. */
       void add(TransferElementAbstractor element);
+      void add(boost::shared_ptr<TransferElement> element);
 
       /** Finalise the group. From this point on, add() may no longer be called. Only after the group has been finalised
        *  the read functions of this group may be called. Also, after the group has been finalised, read functions may
@@ -122,6 +124,13 @@ namespace ChimeraTK {
 
   /********************************************************************************************************************/
 
+  inline ReadAnyGroup::ReadAnyGroup(std::initializer_list<boost::shared_ptr<TransferElement>> list) {
+    for(auto &element : list) add(element);
+    finalise();
+  }
+
+  /********************************************************************************************************************/
+
   template<typename ITERATOR>
   ReadAnyGroup::ReadAnyGroup(ITERATOR first, ITERATOR last) {
     for(ITERATOR it = first; it != last; ++it) add(*it);
@@ -143,6 +152,12 @@ namespace ChimeraTK {
     else {
       poll_elements.push_back(element);
     }
+  }
+
+  /********************************************************************************************************************/
+
+  inline void ReadAnyGroup::add(boost::shared_ptr<TransferElement> element) {
+    add(TransferElementAbstractor(element));
   }
 
   /********************************************************************************************************************/

--- a/device/include/TransferElementAbstractor.h
+++ b/device/include/TransferElementAbstractor.h
@@ -44,6 +44,11 @@ namespace ChimeraTK {
 
     public:
 
+      /** Construct from TransferElement implementation */
+      explicit TransferElementAbstractor(boost::shared_ptr< TransferElement > impl)
+      : _impl(impl)
+      {}
+
       /** Create an uninitialised abstractor - just for late initialisation */
       TransferElementAbstractor() {}
 
@@ -244,11 +249,6 @@ namespace ChimeraTK {
       }
 
     protected:
-
-      /** Construct from TransferElement implementation */
-      explicit TransferElementAbstractor(boost::shared_ptr< TransferElement > impl)
-      : _impl(impl)
-      {}
 
       /** Untyped pointer to implementation */
       boost::shared_ptr< TransferElement > _impl;


### PR DESCRIPTION
Allows to create a ReadAnyGroup from pointers to TransferElements (or derived classes like the NDRegisterAccessor), while currently one needs to have a copy of a TransferElementAbstractor (resp. derived classes like ScalarRegisterAccessor). This is mostly useful for implementations within the framework.

Somehow the constructor of TransferElementAbstractor was made protected, so it could only be used by derived classes. This has now been changed to public. Now anyone can crate TransferElementAbstractor objects from pointers to TransferElements, which is useful in cases where the UserType is unknown (and thus a ScalarRegisterAccessor etc. could not be created).