### PR TITLE
Fix build problems on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 include(cmake/enable_latest_cxx_support.cmake)
 
 # C++ compiler flags needed to compile this project and against this project
-set(${PROJECT_NAME}_CXX_FLAGS "${${PROJECT_NAME}_CXX_FLAGS} -DFUSION_MAX_MAP_SIZE=30 -DFUSION_MAX_VECTOR_SIZE=30")
+set(${PROJECT_NAME}_CXX_FLAGS "${${PROJECT_NAME}_CXX_FLAGS} -DFUSION_MAX_MAP_SIZE=30 -DFUSION_MAX_VECTOR_SIZE=30 -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR")
 
 # set C++ compiler flags for compiling this project
 set(CMAKE_CXX_FLAGS "${${PROJECT_NAME}_CXX_FLAGS} -Wall -Wextra -Wshadow -pedantic -Wuninitialized")

--- a/fileparsers/src/DMapFileParser.cpp
+++ b/fileparsers/src/DMapFileParser.cpp
@@ -27,7 +27,7 @@ namespace ChimeraTK {
     DeviceInfoMapPointer dmap(new DeviceInfoMap(absPathToDMapFile));
     while (std::getline(file, line)) {
       line_nr++;
-      line.erase(line.begin(), std::find_if(line.begin(), line.end(), std::not1(std::ptr_fun<int, int>(isspace))));
+      line.erase(line.begin(), std::find_if(line.begin(), line.end(), [](int c){return !isspace(c);}));
       if (!line.size()) {
         continue;
       }

--- a/fileparsers/src/MapFileParser.cpp
+++ b/fileparsers/src/MapFileParser.cpp
@@ -38,7 +38,7 @@ namespace ChimeraTK {
       bool failed = false;
       line_nr++;
       // Remove whitespace from beginning of line
-      line.erase(line.begin(), std::find_if(line.begin(), line.end(), std::not1(std::ptr_fun<int,int>(isspace))));
+      line.erase(line.begin(), std::find_if(line.begin(), line.end(), [](int c){return !isspace(c);}));
       if (!line.size())       {continue;}
       if (line[0] == '#')     {continue;}
       if (line[0] == '@'){
@@ -47,14 +47,14 @@ namespace ChimeraTK {
         // Remove the '@' character...
         line.erase(line.begin(), line.begin() + 1);
         // ... and remove all the whitespace after it
-        line.erase(line.begin(), std::find_if(line.begin(), line.end(), std::not1(std::ptr_fun<int,int>(isspace))));
+        line.erase(line.begin(), std::find_if(line.begin(), line.end(), [](int c){return !isspace(c);}));
         is.str(line);
         is >> md.name;
         if (!is){
           throw ChimeraTK::logic_error("Parsing error in map file '"+file_name+"' on line "+std::to_string(line_nr));
         }
         line.erase(line.begin(), line.begin() + md.name.length());
-        line.erase(line.begin(), std::find_if(line.begin(), line.end(), std::not1(std::ptr_fun<int,int>(isspace))));
+        line.erase(line.begin(), std::find_if(line.begin(), line.end(), [](int c){return !isspace(c);}));
         md.value = line;
         pmap->insert(md);
         is.clear();


### PR DESCRIPTION
This PR makes two changes:

1. It avoids the use of deprecated / removed C++ features. This is an easy fix because those features where only needed before lambda expressions where added to C++.
2. It defines the `_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR` preprocessor macro so that `std::auto_ptr` is made available when compiling in C++ 17 mode and with libc++.

The second change is not very elegant, but needed because libxml++ 2.6 needs `std::auto_ptr`. This has been fixed in more recent releases of libxml++, so we should check whether we can move to libxml++ 3.x as soon as practical.