### PR TITLE
Behavior change for Rebot backend.

### DIFF
--- a/device_backends/Rebot/include/RebotBackend.h
+++ b/device_backends/Rebot/include/RebotBackend.h
@@ -57,6 +57,7 @@ namespace ChimeraTK {
     /// The function opens the connection to the device
     void open() override;
     void close() override;
+    bool isConnected() override;
     void read(uint8_t bar, uint32_t addressInBytes, int32_t* data, size_t sizeInBytes) override;
     void write(uint8_t bar, uint32_t addressInBytes, int32_t const* data, size_t sizeInBytes) override;
     std::string readDeviceInfo() override { return std::string("RebotDevice"); }
@@ -71,6 +72,7 @@ namespace ChimeraTK {
     uint32_t getServerProtocolVersion();
     std::vector<uint32_t> frameClientHello();
     uint32_t parseRxServerHello(const std::vector<int32_t>& serverHello);
+    std::unique_ptr<RebotProtocolImplementor> getProtocolImplementor();
 
     void heartbeatLoop(boost::shared_ptr<ThreadInformerMutex> threadInformerMutex);
     boost::thread _heartbeatThread;

--- a/device_backends/Rebot/src/TcpCtrl.cc
+++ b/device_backends/Rebot/src/TcpCtrl.cc
@@ -15,6 +15,10 @@ namespace ChimeraTK {
 
   TcpCtrl::~TcpCtrl() {}
 
+  bool TcpCtrl::isConnected(){
+    return _socket->is_open();
+  }
+
   void TcpCtrl::openConnection() {
     try {
       // Use boost resolver for DNS name resolution when server address is a

--- a/device_backends/Rebot/src/TcpCtrl.h
+++ b/device_backends/Rebot/src/TcpCtrl.h
@@ -43,6 +43,7 @@ namespace ChimeraTK {
     int getPort();
     /// Sets port in an object. Can be done when connection is closed.
     void setPort(int port);
+    bool isConnected();
 
    private:
     /*!

--- a/tests/unitTestsNotUnderCtest/testRebotBackend.cpp
+++ b/tests/unitTestsNotUnderCtest/testRebotBackend.cpp
@@ -113,7 +113,7 @@ void RebotTestClass::testConnection() { // BAckend test
   // create connection with good ip and port see that there are no exceptions
   ChimeraTK::RebotBackend rebotBackend(_rebotServer.ip, _rebotServer.port);
   ChimeraTK::RebotBackend secondConnectionToServer(_rebotServer.ip, _rebotServer.port);
-  BOOST_CHECK_EQUAL(rebotBackend.isConnected(), true);
+  BOOST_CHECK_EQUAL(rebotBackend.isConnected(), false);
   BOOST_CHECK_EQUAL(rebotBackend.isOpen(), false);
 
   BOOST_CHECK_NO_THROW(rebotBackend.open());
@@ -124,7 +124,7 @@ void RebotTestClass::testConnection() { // BAckend test
   // ChimeraTK::RebotBackendException);
 
   BOOST_CHECK_NO_THROW(rebotBackend.close());
-  BOOST_CHECK_EQUAL(rebotBackend.isConnected(), true);
+  BOOST_CHECK_EQUAL(rebotBackend.isConnected(), false);
   BOOST_CHECK_EQUAL(rebotBackend.isOpen(), false);
 }
 


### PR DESCRIPTION
Changes:
- close(): close backend and disconnect from hardware.
- read/write on an unopened backend is a logical error.
- read/write failures are runtime errors that do not close the backend.
- tcp related network failures are runtime errors that do not close the
  backend.