### PR TITLE
Remove testing if device is open.

### DIFF
--- a/device/src/Device.cc
+++ b/device/src/Device.cc
@@ -295,9 +295,7 @@ namespace ChimeraTK {
 
   void Device::open() {
     checkPointersAreNotNull();
-    if(!_deviceBackendPointer->isOpen()) {
-      _deviceBackendPointer->open();
-    }
+    _deviceBackendPointer->open();
   }
 
   /********************************************************************************************************************/

--- a/device/src/Device.cc
+++ b/device/src/Device.cc
@@ -303,10 +303,7 @@ namespace ChimeraTK {
   void Device::open(std::string const& aliasName) {
     BackendFactory& factoryInstance = BackendFactory::getInstance();
     _deviceBackendPointer = factoryInstance.createBackend(aliasName);
-    if(!_deviceBackendPointer->isOpen()) { // createBackend may return an already
-                                           // opened instance for some backends
-      _deviceBackendPointer->open();
-    }
+    _deviceBackendPointer->open();
   }
 
   /********************************************************************************************************************/

--- a/device_backends/SharedDummy/src/SharedDummyBackend.cc
+++ b/device_backends/SharedDummy/src/SharedDummyBackend.cc
@@ -12,15 +12,11 @@
 #include "SharedDummyBackend.h"
 #include "parserUtilities.h"
 
-
 namespace ChimeraTK {
 
   SharedDummyBackend::SharedDummyBackend(std::string instanceId, std::string mapFileName)
-    : DummyBackendBase(mapFileName),
-      _mapFile(mapFileName),
-      _barSizesInBytes(getBarSizesInBytesFromRegisterMapping()),
-      sharedMemoryManager(*this, instanceId, mapFileName)
-  {
+  : DummyBackendBase(mapFileName), _mapFile(mapFileName), _barSizesInBytes(getBarSizesInBytesFromRegisterMapping()),
+    sharedMemoryManager(*this, instanceId, mapFileName) {
     setupBarContents();
   }
 
@@ -31,8 +27,7 @@ namespace ChimeraTK {
   // Construct a segment for each bar and set required size
   void SharedDummyBackend::setupBarContents() {
     for(std::map<uint8_t, size_t>::const_iterator barSizeInBytesIter = _barSizesInBytes.begin();
-        barSizeInBytesIter != _barSizesInBytes.end();
-        ++barSizeInBytesIter) {
+        barSizeInBytesIter != _barSizesInBytes.end(); ++barSizeInBytesIter) {
       std::string barName = SHARED_MEMORY_BAR_PREFIX + std::to_string(barSizeInBytesIter->first);
 
       size_t barSizeInWords = (barSizeInBytesIter->second + sizeof(int32_t) - 1) / sizeof(int32_t);
@@ -53,19 +48,9 @@ namespace ChimeraTK {
     } /* for(barSizesInBytesIter) */
   }
 
-  void SharedDummyBackend::open() {
-    if(_opened) {
-      throw ChimeraTK::logic_error("Device is already open.");
-    }
-    _opened = true;
-  }
+  void SharedDummyBackend::open() { _opened = true; }
 
-  void SharedDummyBackend::close() {
-    if(!_opened) {
-      throw ChimeraTK::logic_error("Device is already closed.");
-    }
-    _opened = false;
-  }
+  void SharedDummyBackend::close() { _opened = false; }
 
   void SharedDummyBackend::read(uint8_t bar, uint32_t address, int32_t* data, size_t sizeInBytes) {
     if(!_opened) {
@@ -115,9 +100,8 @@ namespace ChimeraTK {
     }
   }
 
-  boost::shared_ptr<DeviceBackend> SharedDummyBackend::createInstance(std::string address,
-      std::map<std::string, std::string>
-          parameters) {
+  boost::shared_ptr<DeviceBackend> SharedDummyBackend::createInstance(
+      std::string address, std::map<std::string, std::string> parameters) {
     std::string mapFileName = parameters["map"];
     if(mapFileName == "") {
       throw ChimeraTK::logic_error("No map file name given.");

--- a/device_backends/pcie/src/PcieBackend.cc
+++ b/device_backends/pcie/src/PcieBackend.cc
@@ -29,7 +29,11 @@ namespace ChimeraTK {
     std::cout << "open pcie dev" << std::endl;
 #endif
     if(_opened) {
-      throw ChimeraTK::logic_error("Device already has been opened");
+      // FIXME: This mimics the previous behaviour where the Device would simply discard open calls
+      // if the backend is already opened. The correct behaviour would be a recovery procedure.
+      // At the moment this exceeds the scope of just restoring the previous functionality (you can re-call open)
+      // because it would require extensive testing, even with real hardware.
+      return;
     }
     _deviceID = ::open(_deviceNodeName.c_str(), O_RDWR);
     if(_deviceID < 0) {
@@ -280,9 +284,8 @@ namespace ChimeraTK {
     return startText + _deviceNodeName + ": " + strerror_r(errno, errorBuffer, sizeof(errorBuffer));
   }
 
-  boost::shared_ptr<DeviceBackend> PcieBackend::createInstance(std::string address,
-      std::map<std::string, std::string>
-          parameters) {
+  boost::shared_ptr<DeviceBackend> PcieBackend::createInstance(
+      std::string address, std::map<std::string, std::string> parameters) {
     if(address.size() == 0) {
       throw ChimeraTK::logic_error("Device address not specified.");
     }

--- a/device_backends/src/DummyBackend.cc
+++ b/device_backends/src/DummyBackend.cc
@@ -10,7 +10,6 @@
 #include "parserUtilities.h"
 #include "DummyRegisterAccessor.h"
 
-
 namespace ChimeraTK {
   // Valid bar numbers are 0 to 5 , so they must be contained
   // in three bits.
@@ -18,10 +17,7 @@ namespace ChimeraTK {
   // the bar number is stored in bits 60 to 62
   const unsigned int BAR_POSITION_IN_VIRTUAL_REGISTER = 60;
 
-  DummyBackend::DummyBackend(std::string mapFileName)
-      : DummyBackendBase(mapFileName),
-        _mapFile(mapFileName)
-  {
+  DummyBackend::DummyBackend(std::string mapFileName) : DummyBackendBase(mapFileName), _mapFile(mapFileName) {
     resizeBarContents();
   }
 
@@ -31,9 +27,6 @@ namespace ChimeraTK {
 
   void DummyBackend::open() {
     std::lock_guard<std::mutex> lock(mutex);
-    if(_opened) {
-      throw ChimeraTK::logic_error("Device is already open.");
-    }
     _opened = true;
   }
 
@@ -48,12 +41,8 @@ namespace ChimeraTK {
     }
   }
 
-
   void DummyBackend::close() {
     std::lock_guard<std::mutex> lock(mutex);
-    if(!_opened) {
-      throw ChimeraTK::logic_error("Device is already closed.");
-    }
 
     _readOnlyAddresses.clear();
     _writeCallbackFunctions.clear();
@@ -64,7 +53,6 @@ namespace ChimeraTK {
     std::lock_guard<std::mutex> lock(mutex);
     TRY_REGISTER_ACCESS(_barContents[bar].at(address / sizeof(int32_t)) = data;);
   }
-
 
   void DummyBackend::read(uint8_t bar, uint32_t address, int32_t* data, size_t sizeInBytes) {
     std::lock_guard<std::mutex> lock(mutex);
@@ -107,7 +95,6 @@ namespace ChimeraTK {
     return (static_cast<uint64_t>(bar & BAR_MASK) << BAR_POSITION_IN_VIRTUAL_REGISTER) |
         (static_cast<uint64_t>(registerOffsetInBar));
   }
-
 
   void DummyBackend::setReadOnly(uint8_t bar, uint32_t address, size_t sizeInWords) {
     for(size_t i = 0; i < sizeInWords; ++i) {

--- a/tests/executables_src/testLMapBackend.cpp
+++ b/tests/executables_src/testLMapBackend.cpp
@@ -19,6 +19,12 @@ BOOST_AUTO_TEST_CASE(testExceptions) {
   BOOST_CHECK(device.isOpened() == false);
   device.open("LMAP0");
   BOOST_CHECK(device.isOpened() == true);
+  // you must always be able to re-open a backend. It should try to re-connect, if applicable.
+  device.open();
+  BOOST_CHECK(device.isOpened() == true);
+  device.open("LMAP0");
+  BOOST_CHECK(device.isOpened() == true);
+
   int data = 0;
 
   BOOST_CHECK_THROW(device.write("Channel3", data), ChimeraTK::logic_error);
@@ -27,6 +33,8 @@ BOOST_AUTO_TEST_CASE(testExceptions) {
   BOOST_CHECK_NO_THROW(device.getOneDRegisterAccessor<int>("LastChannelInRegister"));
 
   BOOST_CHECK(device.isOpened() == true);
+  device.close();
+  BOOST_CHECK(device.isOpened() == false);
   device.close();
   BOOST_CHECK(device.isOpened() == false);
 }

--- a/tests/executables_src/testPcieBackend.cpp
+++ b/tests/executables_src/testPcieBackend.cpp
@@ -273,8 +273,7 @@ void PcieBackendTest::testFailIfBackendClosed() {
   _pcieBackendInstance->close();
   BOOST_CHECK_THROW( // _pcieBackendInstance->readReg(WORD_USER_OFFSET,
                      // &dataWord, /*bar*/ 0),
-      _pcieBackendInstance->read(/*bar*/ 0, WORD_USER_OFFSET, &dataWord, 4),
-      ChimeraTK::logic_error);
+      _pcieBackendInstance->read(/*bar*/ 0, WORD_USER_OFFSET, &dataWord, 4), ChimeraTK::logic_error);
   // BOOST_CHECK_THROW(  _pcieBackendInstance->read(WORD_USER_OFFSET, &dataWord,
   // sizeof(dataWord), /*bar*/ 0),
   BOOST_CHECK_THROW(
@@ -430,8 +429,6 @@ void PcieBackendTest::testReadRegister() {
   _pcieBackendInstance->open(); // no need to check if this works because we did
                                 // the open test first
   //_pcieBackendInstance->readReg(WORD_DUMMY_OFFSET, &dataWord, /*bar*/ 0);
-  BOOST_CHECK_THROW(_pcieBackendInstance->open(),
-      ChimeraTK::logic_error); // try opening again will cause an exception
   _pcieBackendInstance->read(/*bar*/ 0, WORD_DUMMY_OFFSET, &dataWord, 4);
   BOOST_CHECK_EQUAL(dataWord, DMMY_AS_ASCII);
 
@@ -467,12 +464,15 @@ void PcieBackendTest::testWriteRegister() {
 
 void PcieBackendTest::testClose() {
   std::cout << "testClose" << std::endl;
-  /** Try closing the backend */
+  /* Try closing the backend */
   _pcieBackendInstance->close();
-  /** backend should not be open now */
+  /* backend should not be open now */
   BOOST_CHECK(_pcieBackendInstance->isOpen() == false);
-  /** backend should remain in connected state */
+  /* backend should remain in connected state */
   BOOST_CHECK(_pcieBackendInstance->isConnected() == true);
+  // It always has to be possible to call close again.
+  _pcieBackendInstance->close();
+  BOOST_CHECK(_pcieBackendInstance->isOpen() == false);
 }
 
 void PcieBackendTest::testOpen() {
@@ -480,6 +480,9 @@ void PcieBackendTest::testOpen() {
   _pcieBackendInstance->open();
   BOOST_CHECK(_pcieBackendInstance->isOpen() == true);
   BOOST_CHECK(_pcieBackendInstance->isConnected() == true);
+  // It must always be possible to re-open a backend. It should try to re-connect.
+  _pcieBackendInstance->open();
+  BOOST_CHECK(_pcieBackendInstance->isOpen());
 }
 
 void PcieBackendTest::testCreateBackend() {

--- a/tests/executables_src/testSubdeviceBackend.cpp
+++ b/tests/executables_src/testSubdeviceBackend.cpp
@@ -35,6 +35,13 @@ BOOST_AUTO_TEST_CASE(testOpenClose) {
   BOOST_CHECK(!dev.isOpened());
   dev.open();
   BOOST_CHECK(dev.isOpened());
+  // It must always be possible to re-open and re-close a backend
+  dev.open();
+  BOOST_CHECK(dev.isOpened());
+  dev.open("SUBDEV1");
+  BOOST_CHECK(dev.isOpened());
+  dev.close();
+  BOOST_CHECK(!dev.isOpened());
   dev.close();
   BOOST_CHECK(!dev.isOpened());
 }

--- a/tests/unitTestsNotUnderCtest/testRebotBackend.cpp
+++ b/tests/unitTestsNotUnderCtest/testRebotBackend.cpp
@@ -120,11 +120,16 @@ void RebotTestClass::testConnection() { // BAckend test
   BOOST_CHECK_EQUAL(rebotBackend.isConnected(), true);
   BOOST_CHECK_EQUAL(rebotBackend.isOpen(), true);
 
-  // BOOST_CHECK_THROW(secondConnectionToServer.open(),
-  // ChimeraTK::RebotBackendException);
+  // it must always be possible to call open() again
+  BOOST_CHECK_NO_THROW(rebotBackend.open());
+  BOOST_CHECK_EQUAL(rebotBackend.isOpen(), true);
 
   BOOST_CHECK_NO_THROW(rebotBackend.close());
   BOOST_CHECK_EQUAL(rebotBackend.isConnected(), true);
+  BOOST_CHECK_EQUAL(rebotBackend.isOpen(), false);
+
+  // it must always be possible to call close() again
+  BOOST_CHECK_NO_THROW(rebotBackend.close());
   BOOST_CHECK_EQUAL(rebotBackend.isOpen(), false);
 }
 


### PR DESCRIPTION
When a device throws an error while reading RegisterAccessor ApllictaionCore modules that use that RegisterAccessors are stopped.
To recover ApplicationCore will call open on the Device. But since isOpen() will still return true the device will not be reopened and e.g. a client conncetion can not be recovered.