### PR TITLE
Move bar index check to NumericAddressedBackend

### DIFF
--- a/device_backends/include/NumericAddressedBackend.h
+++ b/device_backends/include/NumericAddressedBackend.h
@@ -30,6 +30,8 @@ namespace ChimeraTK {
 
     virtual void write(uint8_t bar, uint32_t address, int32_t const* data, size_t sizeInBytes) = 0;
 
+    virtual bool barIndexValid(uint32_t bar);
+
     virtual std::string readDeviceInfo() = 0;
 
     /**

--- a/device_backends/include/NumericAddressedLowLevelTransferElement.h
+++ b/device_backends/include/NumericAddressedLowLevelTransferElement.h
@@ -37,7 +37,7 @@ namespace ChimeraTK {
         boost::shared_ptr<NumericAddressedBackend> dev, size_t bar, size_t startAddress, size_t numberOfBytes)
     : TransferElement("", {AccessMode::raw}), _dev(dev), _bar(bar), isShared(false),
       _unalignedAccess(_dev->_unalignedAccess, std::defer_lock) {
-      if(bar > 5 && bar != 13) {
+      if(!dev->barIndexValid(bar)) {
         std::stringstream errorMessage;
         errorMessage << "Invalid bar number: " << bar << std::endl;
         throw ChimeraTK::logic_error(errorMessage.str());

--- a/device_backends/src/NumericAddressedBackend.cc
+++ b/device_backends/src/NumericAddressedBackend.cc
@@ -81,6 +81,11 @@ namespace ChimeraTK {
     write(retRegBar, retRegOff, data, retDataSize);
   }
 
+  // Default range of valid BARs
+  bool NumericAddressedBackend::barIndexValid(uint32_t bar) {
+    return bar <= 5 || bar == 13; 
+  }
+
   /********************************************************************************************************************/
 
   boost::shared_ptr<const RegisterInfoMap> NumericAddressedBackend::getRegisterMap() const { return _registerMap; }


### PR DESCRIPTION
`NumericAddressedLowLevelTransferElement` shouldn't know details about which BAR values are valid and which ones are not. This patch delegates that check to the `NumericAddressedBackend` implementation. By default, it performs the same check that was done in `NumericAddressedLowLevelTransferElement` constructor before. Now a subclass of `NumericAddressedBackend` can override that check and re-define which BAR values are valid.