### PR TITLE
Change address type to uint64_t for new backends

### DIFF
--- a/device_backends/include/DummyRegisterAccessor.h
+++ b/device_backends/include/DummyRegisterAccessor.h
@@ -189,7 +189,13 @@ namespace ChimeraTK {
     /// Set callback function which is called when the register is written to (through the normal Device interface)
     void setWriteCallback(const std::function<void()>& writeCallback) {
       _dev->setWriteCallbackFunction(
-          {uint8_t(registerInfo.bar), registerInfo.address, registerInfo.nBytes}, writeCallback);
+        {
+          static_cast<uint8_t>(registerInfo.bar),
+          static_cast<uint32_t>(registerInfo.address),
+          registerInfo.nBytes
+        },
+        writeCallback
+      );
     }
 
    protected:

--- a/device_backends/include/NumericAddressedBackend.h
+++ b/device_backends/include/NumericAddressedBackend.h
@@ -20,9 +20,12 @@ namespace ChimeraTK {
 
     virtual ~NumericAddressedBackend() {}
 
-    virtual void read(uint8_t bar, uint32_t address, int32_t* data, size_t sizeInBytes) = 0;
+    /* interface using 32bit address for backwards compatibility */
+    virtual void read(uint8_t bar, uint32_t address, int32_t* data, size_t sizeInBytes);
+    virtual void write(uint8_t bar, uint32_t address, int32_t const* data, size_t sizeInBytes);
 
-    virtual void write(uint8_t bar, uint32_t address, int32_t const* data, size_t sizeInBytes) = 0;
+    virtual void read(uint8_t bar, uint64_t address, int32_t* data, size_t sizeInBytes);
+    virtual void write(uint8_t bar, uint64_t address, int32_t const* data, size_t sizeInBytes);
 
     virtual std::string readDeviceInfo() = 0;
 

--- a/device_backends/src/NumericAddressedBackend.cc
+++ b/device_backends/src/NumericAddressedBackend.cc
@@ -57,6 +57,30 @@ namespace ChimeraTK {
     }
   }
 
+  /* Throw exception if called directly and not implemented by backend */
+  void NumericAddressedBackend::read([[maybe_unused]] uint8_t bar,
+                                     [[maybe_unused]] uint32_t address,
+                                     [[maybe_unused]] int32_t* data,
+                                     [[maybe_unused]] size_t sizeInBytes) {
+    throw ChimeraTK::logic_error("NumericAddressedBackend: internal error: interface read() called w/ 32bit address");
+  }
+
+  void NumericAddressedBackend::write([[maybe_unused]] uint8_t bar,
+                                      [[maybe_unused]] uint32_t address,
+                                      [[maybe_unused]] int32_t const* data,
+                                      [[maybe_unused]] size_t sizeInBytes) {
+    throw ChimeraTK::logic_error("NumericAddressedBackend: internal error: interface write() called w/ 32bit address");
+  }
+
+  /* Call 32-bit address implementation by default, for backends that don't implement 64-bit */
+  void NumericAddressedBackend::read(uint8_t bar, uint64_t address, int32_t* data, size_t sizeInBytes) {
+    read(bar, address, data, sizeInBytes);
+  }
+
+  void NumericAddressedBackend::write(uint8_t bar, uint64_t address, int32_t const* data, size_t sizeInBytes) {
+    write(bar, address, data, sizeInBytes);
+  }
+
   /********************************************************************************************************************/
 
   boost::shared_ptr<const RegisterInfoMap> NumericAddressedBackend::getRegisterMap() const { return _registerMap; }

--- a/device_backends/src/NumericAddressedBackend.cc
+++ b/device_backends/src/NumericAddressedBackend.cc
@@ -74,11 +74,11 @@ namespace ChimeraTK {
 
   /* Call 32-bit address implementation by default, for backends that don't implement 64-bit */
   void NumericAddressedBackend::read(uint8_t bar, uint64_t address, int32_t* data, size_t sizeInBytes) {
-    read(bar, address, data, sizeInBytes);
+    read(bar, static_cast<uint32_t>(address), data, sizeInBytes);
   }
 
   void NumericAddressedBackend::write(uint8_t bar, uint64_t address, int32_t const* data, size_t sizeInBytes) {
-    write(bar, address, data, sizeInBytes);
+    write(bar, static_cast<uint32_t>(address), data, sizeInBytes);
   }
 
   /********************************************************************************************************************/

--- a/fileparsers/include/RegisterInfoMap.h
+++ b/fileparsers/include/RegisterInfoMap.h
@@ -97,7 +97,7 @@ namespace ChimeraTK {
       uint32_t nChannels;      /**< Number of channels/sequences */
       bool is2DMultiplexed;    /**< Flag if register is a 2D multiplexed
                                         register (otherwise it is 1D or scalar) */
-      uint32_t address;        /**< Relative address in bytes from beginning  of
+      uint64_t address;        /**< Relative address in bytes from beginning  of
                                         the bar(Base Address Range)*/
       uint32_t nBytes;         /**< Size of register expressed in bytes */
       uint32_t bar;            /**< Number of bar with register */
@@ -116,7 +116,7 @@ namespace ChimeraTK {
       /// Constructor to set all data members. They all have default values, so
       /// this also acts as default constructor.
       RegisterInfo(std::string const& name_ = std::string(), // an empty string
-          uint32_t nElements_ = 0, uint32_t address_ = 0, uint32_t nBytes_ = 0, uint32_t bar_ = 0, uint32_t width_ = 32,
+          uint32_t nElements_ = 0, uint64_t address_ = 0, uint32_t nBytes_ = 0, uint32_t bar_ = 0, uint32_t width_ = 32,
           int32_t nFractionalBits_ = 0, bool signedFlag_ = true, std::string const& module_ = std::string(),
           uint32_t nChannels_ = 1, bool is2DMultiplexed_ = false, Access dataAccess_ = Access::READWRITE,
           Type dataType_ = Type::FIXED_POINT);

--- a/fileparsers/src/MapFileParser.cpp
+++ b/fileparsers/src/MapFileParser.cpp
@@ -22,7 +22,7 @@ namespace ChimeraTK {
     RegisterInfoMapPointer pmap(new RegisterInfoMap(file_name));
     std::string name;        /**< Name of register */
     uint32_t nElements;      /**< Number of elements in register */
-    uint32_t address;        /**< Relative address in bytes from beginning  of the
+    uint64_t address;        /**< Relative address in bytes from beginning  of the
                                 bar(Base Address Range)*/
     uint32_t nBytes;         /**< Size of register expressed in bytes */
     uint32_t bar;            /**< Number of bar with register */

--- a/fileparsers/src/RegisterInfoMap.cpp
+++ b/fileparsers/src/RegisterInfoMap.cpp
@@ -57,8 +57,8 @@ namespace ChimeraTK {
   namespace {
 
     typedef struct _addresses {
-      uint32_t start;
-      uint32_t end;
+      uint64_t start;
+      uint64_t end;
       std::vector<RegisterInfoMap::RegisterInfo>::iterator iter;
     } addresses;
 
@@ -274,7 +274,7 @@ namespace ChimeraTK {
   RegisterInfoMap::MetaData::MetaData(std::string const& name_, std::string const& value_)
   : name(name_), value(value_) {}
 
-  RegisterInfoMap::RegisterInfo::RegisterInfo(std::string const& name_, uint32_t nElements_, uint32_t address_,
+  RegisterInfoMap::RegisterInfo::RegisterInfo(std::string const& name_, uint32_t nElements_, uint64_t address_,
       uint32_t nBytes_, uint32_t bar_, uint32_t width_, int32_t nFractionalBits_, bool signedFlag_,
       std::string const& module_, uint32_t nChannels_, bool is2DMultiplexed_, Access dataAccess_, Type dataType_)
   : name(name_), nElements(nElements_), nChannels(nChannels_), is2DMultiplexed(is2DMultiplexed_), address(address_),


### PR DESCRIPTION
The XDMA driver allows transparent access to the whole FPGA memory, which can be a 64-bit address space on the bigger boards.
This patch changes the address type to uint64_t. It keeps the existing 32-bit interface for existing backends.