### PR TITLE
Fix compiler warnings

### DIFF
--- a/device_backends/include/UnifiedBackendTest.h
+++ b/device_backends/include/UnifiedBackendTest.h
@@ -1715,7 +1715,7 @@ namespace ChimeraTK {
 
       // First step: measure time until initial value arrives, so we know how long to wait to exclude that an initial
       // value arrives wrongly.
-      std::chrono::duration<double> timeToInitialValue;
+      std::chrono::duration<double> timeToInitialValue {};
       {
         // start time measurement
         auto t0 = std::chrono::steady_clock::now();


### PR DESCRIPTION
Build with g++ 9.3.0 produces a wall of text about 'no user-provided default constructor' (see abbreviated example below)

```
../device_backends/include/UnifiedBackendTest.h: In instantiation of ‘ChimeraTK::UnifiedBackendTest<VECTOR_OF_REGISTERS_T>::test_B_8_5() [with VECTOR_OF_REGISTERS_T = boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>]::<lambda(auto:60)> [with auto:60 = SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>]’:
/usr/include/boost/mpl/for_each.hpp:78:26:   required from ‘static void boost::mpl::aux::for_each_impl<false>::execute(Iterator*, LastIterator*, TransformFunc*, F) [with Iterator = boost::mpl::v_iter<boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>, 1>; LastIterator = boost::mpl::v_iter<boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>, 2>; TransformFunc = boost::mpl::identity<mpl_::na>; F = ChimeraTK::UnifiedBackendTest<VECTOR_OF_REGISTERS_T>::test_B_8_5() [with VECTOR_OF_REGISTERS_T = boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>]::<lambda(auto:60)>]’
/usr/include/boost/mpl/for_each.hpp:82:22:   required from ‘static void boost::mpl::aux::for_each_impl<false>::execute(Iterator*, LastIterator*, TransformFunc*, F) [with Iterator = boost::mpl::v_iter<boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>, 0>; LastIterator = boost::mpl::v_iter<boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>, 2>; TransformFunc = boost::mpl::identity<mpl_::na>; F = ChimeraTK::UnifiedBackendTest<VECTOR_OF_REGISTERS_T>::test_B_8_5() [with VECTOR_OF_REGISTERS_T = boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>]::<lambda(auto:60)>]’
/usr/include/boost/mpl/for_each.hpp:105:18:   required from ‘void boost::mpl::for_each(F, Sequence*, TransformOp*) [with Sequence = boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>; TransformOp = boost::mpl::identity<mpl_::na>; F = ChimeraTK::UnifiedBackendTest<VECTOR_OF_REGISTERS_T>::test_B_8_5() [with VECTOR_OF_REGISTERS_T = boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>]::<lambda(auto:60)>]’
/usr/include/boost/mpl/for_each.hpp:118:46:   required from ‘void boost::mpl::for_each(F, Sequence*) [with Sequence = boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>; F = ChimeraTK::UnifiedBackendTest<VECTOR_OF_REGISTERS_T>::test_B_8_5() [with VECTOR_OF_REGISTERS_T = boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>]::<lambda(auto:60)>]’
../device_backends/include/UnifiedBackendTest.h:1710:48:   required from ‘void ChimeraTK::UnifiedBackendTest<VECTOR_OF_REGISTERS_T>::test_B_8_5() [with VECTOR_OF_REGISTERS_T = boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>]’
../device_backends/include/UnifiedBackendTest.h:821:5:   required from ‘void ChimeraTK::UnifiedBackendTest<VECTOR_OF_REGISTERS_T>::runTests(const string&, const string&) [with VECTOR_OF_REGISTERS_T = boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyArea1>, boost::mpl::v_item<SubdeviceBackendUnifiedTestSuite::Regs3Type<SubdeviceBackendUnifiedTestSuite::MyRegister1>, boost::mpl::vector<mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na>, 0>, 0>; std::string = std::__cxx11::basic_string<char>]’
../tests/executables_src/testSubdeviceBackendUnified.cpp:184:86:   required from here
/usr/include/c++/9/chrono:300:14: note: ‘struct std::chrono::duration<double>’ has no user-provided default constructor
  300 |       struct duration
      |              ^~~~~~~~
/usr/include/c++/9/chrono:322:12: note: constructor is not user-provided because it is explicitly defaulted in the class body
  322 |  constexpr duration() = default;
      |            ^~~~~~~~
/usr/include/c++/9/chrono:443:6: note: and the implicitly-defined constructor does not initialize ‘std::chrono::duration<double>::rep std::chrono::duration<double>::__r’
  443 |  rep __r;
      |      ^~~
[184/184] Linking CXX executable tests/testSubdeviceBackendUnified
```