### PR TITLE
SubdeviceBackend 2regs/3regs mode: add support for data areas.

### DIFF
--- a/device_backends/Subdevice/include/SubdeviceRegisterAccessor.h
+++ b/device_backends/Subdevice/include/SubdeviceRegisterAccessor.h
@@ -55,7 +55,7 @@ namespace ChimeraTK {
     boost::shared_ptr<NDRegisterAccessor<int32_t>> _accStatus;
 
     /// start address and length
-    size_t _byteOffset, _numberOfWords;
+    size_t _startAddress, _numberOfWords;
 
     /// internal buffer
     std::vector<int32_t> _buffer;

--- a/device_backends/Subdevice/src/SubdeviceBackend.cc
+++ b/device_backends/Subdevice/src/SubdeviceBackend.cc
@@ -394,12 +394,12 @@ namespace ChimeraTK {
     // check if raw transfer?
     bool isRaw = flags.has(AccessMode::raw);
 
-    // obtain target accessor in raw mode
-    auto accAddress = targetDevice->getRegisterAccessor<int32_t>(targetAddress, 1, 0, {AccessMode::raw});
-    auto accData = targetDevice->getRegisterAccessor<int32_t>(targetData, 1, 0, {AccessMode::raw});
+    // obtain target accessors
+    auto accAddress = targetDevice->getRegisterAccessor<int32_t>(targetAddress, 1, 0, {});
+    auto accData = targetDevice->getRegisterAccessor<int32_t>(targetData, 0, 0, {});
     boost::shared_ptr<NDRegisterAccessor<int32_t>> accStatus;
     if(type == Type::threeRegisters) {
-      accStatus = targetDevice->getRegisterAccessor<int32_t>(targetControl, 1, 0, {AccessMode::raw});
+      accStatus = targetDevice->getRegisterAccessor<int32_t>(targetControl, 1, 0, {});
     }
 
     size_t byteOffset = info->address + sizeof(int32_t) * wordOffsetInRegister;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,7 +87,7 @@ MACRO( COPY_MAPPING_FILES )
     mathPlugin.xlmap mathPlugin-broken.xlmap monostableTriggerPlugin.xlmap forceReadOnlyPlugin.xlmap typeHintModifierPlugin.xlmap
     performanceTest.map run_performance_test.sh
     badLoadlib.dmap badLoadlib2.dmap unkownKey.dmap
-    subdeviceTest.dmap Subdevice.map SubdeviceTarget.map
+    subdeviceTest.dmap Subdevice.map SubdeviceMuxedArea.map SubdeviceTarget.map
     shareddummyTest.dmap shareddummy.map
     registerAccess.map floatRawTest.map test3.map unifiedTest.xlmap
     DESTINATION ${PROJECT_BINARY_DIR}/tests)

--- a/tests/SubdeviceMuxedArea.map
+++ b/tests/SubdeviceMuxedArea.map
@@ -1,0 +1,3 @@
+# name                      number of elements        address          size           bar    width   fracbits  signed
+APP.0.THE_AREA_1            10                        0                40             0      32      0         0
+APP.0.THE_AREA_2            25                        7                100            0      32      16        1

--- a/tests/executables_src/testSubdeviceBackend.cpp
+++ b/tests/executables_src/testSubdeviceBackend.cpp
@@ -1,10 +1,12 @@
-#define BOOST_TEST_DYN_LINK
-#define BOOST_TEST_MODULE SubdeviceBackendTest
-#include <boost/test/unit_test.hpp>
-using namespace boost::unit_test_framework;
-
 #include "Device.h"
 #include <thread>
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE SubdeviceBackendTest
+#define BOOST_NO_EXCEPTIONS
+#include <boost/test/unit_test.hpp>
+using namespace boost::unit_test_framework;
+#undef BOOST_NO_EXCEPTIONS
 
 using namespace ChimeraTK;
 
@@ -531,7 +533,7 @@ BOOST_AUTO_TEST_CASE(test3regsArray) {
   BOOST_CHECK(done == false);
   accS = 0;
   accS.write();
-  CHECK_TIMEOUT(accA.read();, (accA == 36), 5000);
+  CHECK_TIMEOUT(accA.read();, (accA == 33), 5000);
   t.join();
   accD.read();
   BOOST_CHECK_EQUAL(static_cast<int32_t>(accD), 456);


### PR DESCRIPTION
This fixes #177 (on github)

Note: This changes existing behaviour in one aspect: previously, the
address written to the address register was incremented in steps of 4
for subsequent low-level transfers of the same high-level register (like
a byte address). This does not make much sense, and likely no use case
relied on this behaviour. It should be noted though that this behaviour
was tested. The tests have been changed accordingly (and extended with
the new functionality).