### PR TITLE
Fix ScalarRegisterAccessors<Boolean> not implicitly converting to bool.

### DIFF
--- a/util/include/SupportedUserTypes.h
+++ b/util/include/SupportedUserTypes.h
@@ -27,8 +27,8 @@ namespace ChimeraTK {
     Boolean() : m_value() {}
     Boolean(bool value) : m_value(value) {}
 
-    operator bool() const { return m_value; }
-    operator bool() { return m_value; }
+    operator const bool&() const { return m_value; }
+    operator bool&() { return m_value; }
     // TODO: test user types to numeric etc
 
    private:


### PR DESCRIPTION
**Background:**

Implicit conversions of ```ScalarRegisterAccessors``` to their ```UserType``` are
frequently used. In case of ```ChimeraTK::Boolean```, often a conversion to
the plain ```bool``` type is required instead, e.g.:

```
ScalarRegisterAccessor<Boolean> myAccessor;
// obtain accessor and read value.
if(myAccessor) doSomething();
```

Without this patch, one had to write instead:
```
if(bool(myAccessor))  doSomething();
```
or
```
if(Boolean(myAccessor)) doSomething();
```

**Implementation:**

This is implemented by adding a template specialisation of
```ChimeraTK::Boolean``` which has implicit conversion to ```bool```. To avoid full
code duplication of the entire class, a second template argument ```TAG``` is
introduced, which allows the template specialisation to inherit
everything else from the generic implementation. This should not have
any negative side effects (apart from maybe cluttering some compiler
error messages with the additional template argument).

**Caveat:**

The change may require a code change of other libraries/application in
some less frequently used cases. This code no longer works:
```
ScalarRegisterAccessor<Boolean> acc1, acc2;
// obtain accessors and read acc1.
acc2 = Boolean(acc1);
```
because the conversion to ```ChimeraTK::Boolean``` is now ambigous. Instead
one has to write:
```
acc2 = bool(acc1);
```
This is mainly problematic in places where template code assigns one
accessor value to another accessor, so an exception has to be
introduced, e.g.:
```
template<typename UserType>
void myFn(ScalarRegisterAccessor<UserType> a,
          ScalarRegisterAccessor<UserType> b) {
  if constexpr(!std::is_same<UserType, Boolean>::value) {
    b = UserType(a);
  }
  else {
    // special case for Boolean
    b = bool(a);
  }
}
```
Since code like this is relatively rare (especially in application code
as opposed to lower level framework/library code), this downside is
accepted in favour of the improved usability in the majority of the use
cases.