### PR TITLE
Wip/9621 math only write with all params

### DIFF
--- a/device_backends/LogicalNameMapping/include/LNMAccessorPlugin.h
+++ b/device_backends/LogicalNameMapping/include/LNMAccessorPlugin.h
@@ -156,14 +156,15 @@ namespace ChimeraTK { namespace LNMBackend {
     void exceptionHook() override;
 
     // This function is starting a loop and will be executed in the _parameterThread;
-    void parameterReadLoop(boost::barrier& waitUntilThreadLaunched);
+    void parameterReadLoop();
 
     bool _isWrite{false};
-    bool _hasPushParameter{false};              // can only be true if _isWrite == true
-    bool _mainValueWrittenAfterOpen{false};     // only needed if _hasPushParameter == true
-    bool _allParametersWrittenAfterOpen{false}; // only needed if _hasPushParameter == true
-    boost::thread _pushParameterWriteThread;    // only used if _hasPushParameter == true
-    ReadAnyGroup _pushParameterReadGroup;       // only used if _hasPushParameter == true
+    bool _hasPushParameter{false};                       // can only be true if _isWrite == true
+    bool _mainValueWrittenAfterOpen{false};              // only needed if _hasPushParameter == true
+    bool _allParametersWrittenAfterOpen{false};          // only needed if _hasPushParameter == true
+    boost::thread _pushParameterWriteThread;             // only used if _hasPushParameter == true
+    boost::barrier _waitUntilParameterThreadLaunched{2}; // sync point for parameter thread and accessor thread
+    ReadAnyGroup _pushParameterReadGroup;                // only used if _hasPushParameter == true
     std::map<std::string, boost::shared_ptr<NDRegisterAccessor<double>>>
         _pushParameterAccessorMap;                 // only used if _hasPushParameter == true
     boost::shared_ptr<MathPluginFormulaHelper> _h; // only used if _hasPushParameter == true

--- a/device_backends/LogicalNameMapping/include/LNMAccessorPlugin.h
+++ b/device_backends/LogicalNameMapping/include/LNMAccessorPlugin.h
@@ -181,6 +181,11 @@ namespace ChimeraTK { namespace LNMBackend {
     std::map<std::string, std::string> _parameters;
     std::string _formula;              // extracted from _parameters
     bool _enablePushParameters{false}; // extracted from _parameters
+
+    // Checks that all parameters have been written since opening the device.
+    // Returns false as long as at least one parameter is still on the backend's _versionOnOpen.
+    bool checkAllParametersWritten(
+        std::map<std::string, boost::shared_ptr<NDRegisterAccessor<double>>> const& accessorsMap);
   };
 
   /** Monostable Trigger Plugin: Write value to target which falls back to another value after defined time. */

--- a/device_backends/LogicalNameMapping/include/LNMAccessorPlugin.h
+++ b/device_backends/LogicalNameMapping/include/LNMAccessorPlugin.h
@@ -159,10 +159,11 @@ namespace ChimeraTK { namespace LNMBackend {
     void parameterReadLoop(boost::barrier& waitUntilThreadLaunched);
 
     bool _isWrite{false};
-    bool _hasPushParameter{false};           // can only be true if _isWrite == true
-    bool _mainValueWrittenAfterOpen{false};  // only needed if _hasPushParameter == true
-    boost::thread _pushParameterWriteThread; // only used if _hasPushParameter == true
-    ReadAnyGroup _pushParameterReadGroup;    // only used if _hasPushParameter == true
+    bool _hasPushParameter{false};              // can only be true if _isWrite == true
+    bool _mainValueWrittenAfterOpen{false};     // only needed if _hasPushParameter == true
+    bool _allParametersWrittenAfterOpen{false}; // only needed if _hasPushParameter == true
+    boost::thread _pushParameterWriteThread;    // only used if _hasPushParameter == true
+    ReadAnyGroup _pushParameterReadGroup;       // only used if _hasPushParameter == true
     std::map<std::string, boost::shared_ptr<NDRegisterAccessor<double>>>
         _pushParameterAccessorMap;                 // only used if _hasPushParameter == true
     boost::shared_ptr<MathPluginFormulaHelper> _h; // only used if _hasPushParameter == true

--- a/device_backends/LogicalNameMapping/include/LNMAccessorPlugin.h
+++ b/device_backends/LogicalNameMapping/include/LNMAccessorPlugin.h
@@ -185,6 +185,8 @@ namespace ChimeraTK { namespace LNMBackend {
 
     // Checks that all parameters have been written since opening the device.
     // Returns false as long as at least one parameter is still on the backend's _versionOnOpen.
+    // Only call this function when holding the _writeMutex. It updates the _allParametersWrittenAfterOpen
+    // variable which is protected by that mutex.
     bool checkAllParametersWritten(
         std::map<std::string, boost::shared_ptr<NDRegisterAccessor<double>>> const& accessorsMap);
   };

--- a/device_backends/LogicalNameMapping/include/LogicalNameMappingBackend.h
+++ b/device_backends/LogicalNameMapping/include/LogicalNameMappingBackend.h
@@ -122,12 +122,10 @@ namespace ChimeraTK {
    private:
     // A version number created when opening the backend. All variables will report this version number until they are changed for the first time
     // after opening the device.
-    ChimeraTK::VersionNumber _versionOnOpen;
-    // We cannot use atomic<VersionNumber> because then share_from_this is not working any more (something with not trivially copyable if I remember correctly)
-    std::mutex _versionOnOpenMutex;
+    std::atomic<ChimeraTK::VersionNumber> _versionOnOpen{ChimeraTK::VersionNumber{nullptr}};
 
    public:
-    ChimeraTK::VersionNumber getVersionOnOpen();
+    ChimeraTK::VersionNumber getVersionOnOpen() const;
   };
 
 } // namespace ChimeraTK

--- a/device_backends/LogicalNameMapping/include/LogicalNameMappingBackend.h
+++ b/device_backends/LogicalNameMapping/include/LogicalNameMappingBackend.h
@@ -118,6 +118,16 @@ namespace ChimeraTK {
 
     /** Obtain list of all target devices referenced in the catalogue */
     std::unordered_set<std::string> getTargetDevices() const;
+
+   private:
+    // A version number created when opening the backend. All variables will report this version number until they are changed for the first time
+    // after opening the device.
+    ChimeraTK::VersionNumber _versionOnOpen;
+    // We cannot use atomic<VersionNumber> because then share_from_this is not working any more (something with not trivially copyable if I remember correctly)
+    std::mutex _versionOnOpenMutex;
+
+   public:
+    ChimeraTK::VersionNumber getVersionOnOpen();
   };
 
 } // namespace ChimeraTK

--- a/device_backends/LogicalNameMapping/src/LogicalNameMappingBackend.cc
+++ b/device_backends/LogicalNameMapping/src/LogicalNameMappingBackend.cc
@@ -51,10 +51,7 @@ namespace ChimeraTK {
     _opened = true;
     _hasException = false;
     _asyncReadActive = false;
-    {
-      std::unique_lock<std::mutex> lk(_versionOnOpenMutex);
-      _versionOnOpen = {};
-    }
+    _versionOnOpen = ChimeraTK::VersionNumber{};
 
     // make sure to update the catalogue from target devices in case they change their catalogue upon open
     catalogueCompleted = false;
@@ -373,10 +370,7 @@ namespace ChimeraTK {
 
   /********************************************************************************************************************/
 
-  ChimeraTK::VersionNumber LogicalNameMappingBackend::getVersionOnOpen() {
-    std::unique_lock<std::mutex> lk(_versionOnOpenMutex);
-    return _versionOnOpen;
-  }
+  ChimeraTK::VersionNumber LogicalNameMappingBackend::getVersionOnOpen() const { return _versionOnOpen; }
 
   /********************************************************************************************************************/
 

--- a/tests/executables_src/testLMapBackendUnified.cpp
+++ b/tests/executables_src/testLMapBackendUnified.cpp
@@ -745,19 +745,6 @@ struct RegVariableAsPushParameterInMathBase : ScalarRegisterDescriptorBase<Deriv
   // the test "sees" the variable which supports wait_for_new_data
   ChimeraTK::AccessModeFlags supportedFlags() { return {ChimeraTK::AccessMode::wait_for_new_data}; }
 
-  template<typename UserType>
-  void generateValueHook(std::vector<UserType>&) {
-    // this is a bit a hack: we know that the test has to generate a value before writing, so we can activate
-    // async read here which is required for the test to be successful. The assumption is that generateValue is not
-    // called before the device is open... FIXME: Better introduce a proper pre-write hook in the UnifiedBackendTest!
-    lmapBackend->activateAsyncRead();
-    // In addion we have to write the accessor which has the math plugin. Otherwise writing of the parameters will
-    // have no effect.
-    auto x = lmapBackend->getRegisterAccessor<double>("/RegisterWithVariableAsPushParameterInMath", 0, 0, {});
-    x->accessData(0) = RegVariableAsPushParameterInMathBase_lastX;
-    x->write();
-  }
-
   typedef double minimumUserType;
   typedef uint32_t rawUserType;
   DummyRegisterAccessor<rawUserType> acc{exceptionDummyLikeMtcadummy.get(), "", "/BOARD.WORD_STATUS"};
@@ -768,6 +755,22 @@ struct RegVariableAsPushParameterInMath_var1
   std::string path() { return "/VariableForMathTest1"; }
 
   const double increment = 17;
+
+  template<typename UserType>
+  void generateValueHook(std::vector<UserType>&) {
+    // this is a bit a hack: we know that the test has to generate a value before writing, so we can activate
+    // async read here which is required for the test to be successful. The assumption is that generateValue is not
+    // called before the device is open... FIXME: Better introduce a proper pre-write hook in the UnifiedBackendTest!
+    lmapBackend->activateAsyncRead();
+    // In addion we have to write the accessor which has the math plugin and the second parameter.
+    // Otherwise writing of the parameters will have no effect.
+    auto x = lmapBackend->getRegisterAccessor<double>("/RegisterWithVariableAsPushParameterInMath", 0, 0, {});
+    x->accessData(0) = RegVariableAsPushParameterInMathBase_lastX;
+    x->write();
+    auto p2 = lmapBackend->getRegisterAccessor<double>("/VariableForMathTest2", 0, 0, {});
+    p2->read();
+    p2->write();
+  }
 
   template<typename T, typename Traw>
   T convertRawToCooked(Traw value) {
@@ -782,6 +785,22 @@ struct RegVariableAsPushParameterInMath_var2
   std::string path() { return "/VariableForMathTest2"; }
 
   const double increment = 23;
+
+  template<typename UserType>
+  void generateValueHook(std::vector<UserType>&) {
+    // this is a bit a hack: we know that the test has to generate a value before writing, so we can activate
+    // async read here which is required for the test to be successful. The assumption is that generateValue is not
+    // called before the device is open... FIXME: Better introduce a proper pre-write hook in the UnifiedBackendTest!
+    lmapBackend->activateAsyncRead();
+    // In addion we have to write the accessor which has the math plugin and the first parameter.
+    // Otherwise writing of the parameters will have no effect.
+    auto x = lmapBackend->getRegisterAccessor<double>("/RegisterWithVariableAsPushParameterInMath", 0, 0, {});
+    x->accessData(0) = RegVariableAsPushParameterInMathBase_lastX;
+    x->write();
+    auto p1 = lmapBackend->getRegisterAccessor<double>("/VariableForMathTest1", 0, 0, {});
+    p1->read();
+    p1->write();
+  }
 
   template<typename T, typename Traw>
   T convertRawToCooked(Traw value) {
@@ -802,6 +821,17 @@ struct RegVariableAsPushParameterInMath_x : RegVariableAsPushParameterInMathBase
     // Note: This in particular is a hack, since we have no guarantee that this gets actually written!
     // FIXME: Better introduce a proper pre-write hook in the UnifiedBackendTest!
     RegVariableAsPushParameterInMathBase_lastX = v[0];
+    // this is a bit a hack: we know that the test has to generate a value before writing, so we can activate
+    // async read here which is required for the test to be successful. The assumption is that generateValue is not
+    // called before the device is open... FIXME: Better introduce a proper pre-write hook in the UnifiedBackendTest!
+    lmapBackend->activateAsyncRead();
+    // In addion we have to write the two parameters. Otherwise writing will have no effect.
+    auto p1 = lmapBackend->getRegisterAccessor<double>("/VariableForMathTest1", 0, 0, {});
+    p1->read();
+    p1->write();
+    auto p2 = lmapBackend->getRegisterAccessor<double>("/VariableForMathTest2", 0, 0, {});
+    p2->read();
+    p2->write();
   }
 
   template<typename T, typename Traw>


### PR DESCRIPTION
The math plugin is only writing if all parameters and the accessor with the math plugin itself have been written once after the device has been opened. This prevents writing several invalid values because the formula has been used without having all data.