### PR TITLE
ReadAnyGroup: Catch runtime_errors while peeking for DiscardValueExceptions

### DIFF
--- a/device/include/ReadAnyGroup.h
+++ b/device/include/ReadAnyGroup.h
@@ -531,6 +531,11 @@ namespace ChimeraTK {
       }
       assert(false); // we must never end up at this point
     }
+    catch(ChimeraTK::runtime_error&) {
+      // While peeking we found another runtime which is stored in the queue.
+      // Don't let it through, but leave it on the queue and continue with the waitAny().
+      // It will be handled later.
+    }
 
     // now that we know that an update is available, we can defer to waitAny()
     return waitAny();


### PR DESCRIPTION
If another exception is on the queue while peeking for a DiscardValueException, this is thrown as well.
It has to be caught and discarded. Otherwise it shows up at the wrong place.
It stays on the queue and is handles later.