### PR TITLE
Fix test

### DIFF
--- a/device_backends/include/UnifiedBackendTest.h
+++ b/device_backends/include/UnifiedBackendTest.h
@@ -3118,9 +3118,10 @@ namespace ChimeraTK {
       auto registerName = x.path();
       std::cout << "    registerName = " << registerName << std::endl;
       auto reg = d.getTwoDRegisterAccessor<UserType>(registerName, 0, 0, {AccessMode::wait_for_new_data});
-      reg.read(); // initial value
 
       for(size_t i = 0; i < x.nRuntimeErrorCases(); ++i) {
+        reg.read(); // initial value
+        
         // enable exceptions on read
         x.setForceRuntimeError(true, i);
 


### PR DESCRIPTION
When a second error type is tested the initial value is set in line line https://github.com/ChimeraTK/DeviceAccess/blob/abe271357af47938eb399c4fb17ee25eae2797ad/device_backends/include/UnifiedBackendTest.h#L3144. This initial value is read in https://github.com/ChimeraTK/DeviceAccess/blob/abe271357af47938eb399c4fb17ee25eae2797ad/device_backends/include/UnifiedBackendTest.h#L3128. So the test fails because the runtime_error is tested. 
Reading the initial value inside the for loop fixes the test.