### PR TITLE
xdma: Reduce mmapSize to actual available space

### DIFF
--- a/device_backends/xdma/include/CtrlIntf.h
+++ b/device_backends/xdma/include/CtrlIntf.h
@@ -12,8 +12,11 @@ namespace ChimeraTK {
     DeviceFile _file;
     void* _mem;
 
-    // Map whole PCIe BAR area (16 MiB)
-    static constexpr size_t _mmapSize = 16 * (1024 * 1024);
+    // Size of mmap'ed area in PCI BAR
+    size_t _mmapSize;
+    // 4 KiB is the minimum size available in Vivado
+    static constexpr size_t _mmapSizeMin = 4 * 1024;
+    static constexpr size_t _mmapSizeMax = 16 * 1024 * 1024;
 
     volatile int32_t* _reg_ptr(uintptr_t offs) const;
     void _check_range(const std::string access_type, uintptr_t address, size_t nBytes) const;


### PR DESCRIPTION
The current version of XDMA Backend `mmap()`s a fixed amount of 16 MiB on the PCIe-AXI bridge BAR and doesn't check the return value. If the FPGA design provides an address space smaller than that, `mmap()` fails and subsequent accesses trigger a segfault.

Since we can't query the actual size from userspace with the current driver as-is (would need to make a fork of Xilinx' driver), this patch "brute force" `mmap()`s with decreasing size until it is successful; starting with 16 MiB, shrinking the size by half, each time `mmap()` fails, until a minimum size of 4 KiB is reached. (The address space exposed through PCIe is always 2^x bytes in size).

If a register access is beyond the mapped space, `CtrlIntf::_check_range()` will trigger an exception.