### PR TITLE
Pr/fix interrupt thread safety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ Project(ChimeraTK-DeviceAccess)
 
 set(${PROJECT_NAME}_MAJOR_VERSION 03)
 set(${PROJECT_NAME}_MINOR_VERSION 02)
-set(${PROJECT_NAME}_PATCH_VERSION 00)
+set(${PROJECT_NAME}_PATCH_VERSION 01)
 include(cmake/set_version_numbers.cmake)
 
 # C++ compiler flags needed to compile this project and against this project

--- a/device_backends/NumericAddressedBackend/include/NumericAddressedBackend.h
+++ b/device_backends/NumericAddressedBackend/include/NumericAddressedBackend.h
@@ -164,8 +164,15 @@ namespace ChimeraTK {
     /** 
      *  This variable is private so the map cannot be altered by derriving backends. The only thing the backends have to
      *  do is trigger an interrupt, and this is done through dispatchInterrupt() which makes sure that the map is not modified.
+     *  This map is filled in the constructor. The rest of the code is accessing it through the const _interruptDispatchers
+     *  reference, which is thread safe.
      */
-    std::map<std::pair<int, int>, boost::shared_ptr<NumericAddressedInterruptDispatcher>> _interruptDispatchers;
+    std::map<std::pair<int, int>, boost::shared_ptr<NumericAddressedInterruptDispatcher>> _interruptDispatchersNonConst;
+
+    /** Access to const members of std::containers is thread safe. So we use a const reference throughout the code.
+     */
+    std::map<std::pair<int, int>, boost::shared_ptr<NumericAddressedInterruptDispatcher>> const& _interruptDispatchers{
+        _interruptDispatchersNonConst};
   };
 
 } // namespace ChimeraTK

--- a/device_backends/NumericAddressedBackend/src/NumericAddressedBackend.cc
+++ b/device_backends/NumericAddressedBackend/src/NumericAddressedBackend.cc
@@ -31,7 +31,7 @@ namespace ChimeraTK {
       for(auto& interruptController : _registerMap.getListOfInterrupts()) {
         // interruptController is a pair<int, set<int>>, containing the controller number and a set of associated interrupts
         for(auto interruptNumber : interruptController.second) {
-          _interruptDispatchers[{interruptController.first, interruptNumber}] =
+          _interruptDispatchersNonConst[{interruptController.first, interruptNumber}] =
               boost::make_shared<NumericAddressedInterruptDispatcher>();
         }
       }
@@ -116,7 +116,7 @@ namespace ChimeraTK {
       }
 
       auto interruptDispatcher =
-          _interruptDispatchers[{registerInfo.interruptCtrlNumber, registerInfo.interruptNumber}];
+          _interruptDispatchers.at({registerInfo.interruptCtrlNumber, registerInfo.interruptNumber});
       assert(interruptDispatcher);
       auto newSubscriber = interruptDispatcher->subscribe<UserType>(
           boost::dynamic_pointer_cast<NumericAddressedBackend>(shared_from_this()), registerPathName, numberOfWords,
@@ -214,7 +214,6 @@ namespace ChimeraTK {
       throw ChimeraTK::runtime_error("NumericAddressedBackend is in exception state.");
     }
     catch(...) {
-      // FIXME: This is not thread-safe!
       for(auto& it : _interruptDispatchers) {
         it.second->sendException(std::current_exception());
       }

--- a/device_backends/pcie/src/PcieBackend.cc
+++ b/device_backends/pcie/src/PcieBackend.cc
@@ -286,7 +286,8 @@ namespace ChimeraTK {
     if(ioctl(_deviceID, _ioctlDriverVersion, &ioctlData) < 0) {
       throw ChimeraTK::runtime_error(createErrorStringWithErrnoText("Cannot read device info: "));
     }
-    os << " DRV VER: " << (float)(ioctlData.offset / 10.0) + (float)ioctlData.data;
+    // major and minor version are in data and offset, respectively
+    os << " DRV VER: " << ioctlData.data << "." << ioctlData.offset;
     return os.str();
   }
 

--- a/tests/executables_src/testPcieBackend.cpp
+++ b/tests/executables_src/testPcieBackend.cpp
@@ -281,7 +281,7 @@ void PcieBackendTest::testReadDeviceInfo() {
 
   std::string deviceInfo;
   deviceInfo = _pcieBackendInstance->readDeviceInfo();
-  BOOST_CHECK(referenceInfo.str() == deviceInfo);
+  BOOST_CHECK_EQUAL(referenceInfo.str(), deviceInfo);
 }
 
 /*******************************************************************************************************************/


### PR DESCRIPTION
Use a const reference of the interrupt dispatcher map in NumericAddressedBackend to make sure that acces is thread safe.

Also includes a fix for the version number reported by the device info of PCIe backend. Was broken with version 0.10 if the dummy driver (only worked for minor version between 1 and 9).