### PR TITLE
fix LNM math plugin push parameters in device recovery (cf. #9961)

### DIFF
--- a/device_backends/LogicalNameMapping/include/LNMBackendVariableAccessor.h
+++ b/device_backends/LogicalNameMapping/include/LNMBackendVariableAccessor.h
@@ -138,7 +138,7 @@ namespace ChimeraTK {
         cppext::future_queue<typename LNMVariable::ValueTable<T>::QueuedValue> queue(3);
         // place queue in map
         vtEntry.subscriptions[this->getId()] = queue;
-        // make void-typed continuationof subscription queue, which stores the received value into the _queueValue
+        // make void-typed continuation of subscription queue, which stores the received value into the _queueValue
         this->_readQueue = queue.template then<void>(
             [this](const typename LNMVariable::ValueTable<T>::QueuedValue& queueValue) {
               this->_queueValue.validity = queueValue.validity;

--- a/device_backends/LogicalNameMapping/src/LNMMathPlugin.cc
+++ b/device_backends/LogicalNameMapping/src/LNMMathPlugin.cc
@@ -192,7 +192,9 @@ namespace ChimeraTK { namespace LNMBackend {
           if(!checkAllParametersWritten(_pushParameterAccessorMap)) {
             continue;
           }
-          if(!_mainValueWrittenAfterOpen) continue;
+          if(!_mainValueWrittenAfterOpen) {
+            continue;
+          }
 
           _h->computeResult(_lastWrittenValue, target->accessChannel(0));
           target->writeDestructively();


### PR DESCRIPTION
Previously, the MathPlugin would ignore incoming updates from parameters
if they were pushed in activateAsyncRead(), even if they were written
between the call to open() and activateAsyncRead(). This is a severe
issue, since ApplicationCore is first recovering all device registers
and then calling activateAsyncRead().

Note: The fix needs also a change in ApplicationCore, since it
previously writes the recovery values with the VersionNumber from the
last write, which was before the call to open().

Another solution to this problem would be to accept variable parameters
in the MathPlugin which have been written at least once after creating
the backend (in contrast to after the last call to open()). This
solution was rejected, since it would cause the MathPlugin's target
register to be written many times during device recovery (once per
parameter plus one time for the main value).