### PR TITLE
Wip/8141 add convenience functions for accessor read/write

### DIFF
--- a/device/include/ScalarRegisterAccessor.h
+++ b/device/include/ScalarRegisterAccessor.h
@@ -104,6 +104,10 @@ namespace ChimeraTK {
      */
     void writeIfDifferent(UserType newValue, VersionNumber versionNumber = VersionNumber{nullptr});
 
+    void setAndWrite(UserType newValue, VersionNumber versionNumber = VersionNumber{nullptr});
+
+    UserType readAndGet();
+
     friend class TransferGroup;
 
     using NDRegisterAccessorAbstractor<UserType>::get;
@@ -237,6 +241,23 @@ namespace ChimeraTK {
   }
 
   /********************************************************************************************************************/
+
+  template<typename UserType, typename TAG>
+  void ScalarRegisterAccessor<UserType, TAG>::setAndWrite(UserType newValue, VersionNumber versionNumber) {
+    operator=(newValue);
+    if(versionNumber == VersionNumber{nullptr}) versionNumber = {};
+    this->write(versionNumber);
+  }
+
+  /********************************************************************************************************************/
+
+  template<typename UserType, typename TAG>
+  UserType ScalarRegisterAccessor<UserType, TAG>::readAndGet() {
+    this->read();
+    return get()->accessData(0, 0);
+  }
+
+  /********************************************************************************************************************/
   /********************************************************************************************************************/
 
   inline ScalarRegisterAccessor<std::string>::ScalarRegisterAccessor(
@@ -269,7 +290,6 @@ namespace ChimeraTK {
   }
 
   /********************************************************************************************************************/
-
   // Do not declare the template for all user types as extern here.
   // This could avoid optimisation of the inline code.
 

--- a/device/include/ScalarRegisterAccessor.h
+++ b/device/include/ScalarRegisterAccessor.h
@@ -104,8 +104,16 @@ namespace ChimeraTK {
      */
     void writeIfDifferent(UserType newValue, VersionNumber versionNumber = VersionNumber{nullptr});
 
+    /**
+     * Convenience function to set and write new value. The given version number
+     * is only used in case the value differs. If versionNumber == {nullptr}, a new version number is generated only if
+     * the write actually takes place.
+     */
     void setAndWrite(UserType newValue, VersionNumber versionNumber = VersionNumber{nullptr});
 
+    /**
+     * Convenience function to read and return a value of UserType.
+     */
     UserType readAndGet();
 
     friend class TransferGroup;

--- a/tests/executables_src/testScalarRegisterAccessor.cpp
+++ b/tests/executables_src/testScalarRegisterAccessor.cpp
@@ -144,6 +144,24 @@ BOOST_AUTO_TEST_CASE(testIntRegisterAccessor) {
   accessor.setAndWrite(4711);
   BOOST_CHECK(dummy == 4711);
 
+  // test writeIfDifferent
+  accessor = 501;
+  accessor.write();
+  VersionNumber vnBefore = accessor.getVersionNumber();
+  accessor.writeIfDifferent(501); // should not write
+  VersionNumber vnAfter = accessor.getVersionNumber();
+  BOOST_CHECK(vnAfter == vnBefore);
+  vnBefore = accessor.getVersionNumber();
+  accessor.writeIfDifferent(502); // should write
+  vnAfter = accessor.getVersionNumber();
+  BOOST_CHECK(vnAfter != vnBefore);
+  // test writeIfDifferent for newly created accessors:
+  ScalarRegisterAccessor<int> freshAccessor = device.getScalarRegisterAccessor<int>("APP0/WORD_STATUS");
+  vnBefore = freshAccessor.getVersionNumber();
+  freshAccessor.writeIfDifferent(0); // should write
+  vnAfter = freshAccessor.getVersionNumber();
+  BOOST_CHECK(vnAfter != vnBefore);
+
   device.close();
 }
 

--- a/tests/executables_src/testScalarRegisterAccessor.cpp
+++ b/tests/executables_src/testScalarRegisterAccessor.cpp
@@ -135,6 +135,15 @@ BOOST_AUTO_TEST_CASE(testIntRegisterAccessor) {
   accessor.write();
   BOOST_CHECK(dummy == 119);
 
+  // test readAndGet
+  accessor = 470;
+  accessor.write();
+  BOOST_CHECK(accessor.readAndGet() == 470);
+
+  // test setAndWrite
+  accessor.setAndWrite(4711);
+  BOOST_CHECK(dummy == 4711);
+
   device.close();
 }
 


### PR DESCRIPTION
The `ScalarRegisterAccessor` was extended with two methods: 

- `void setAndWrite(UserType newValue, VersionNumber versionNumber`
- `UserType readAndGet()`

Test cases have been added for the two above and also for: 
- `void writeIfDifferent(UserType newValue, VersionNumber versionNumber)`

Special `writeCounting` backend for `writeIfDifferent` implemented.

`setAndWrite` was implemented as a standalone method and not integrated into write to avoid confusion between `VersionNumber` and `UserType` data.