### PR TITLE
avoid object slicing in ReadAnyGroup

### DIFF
--- a/device/include/ReadAnyGroup.h
+++ b/device/include/ReadAnyGroup.h
@@ -4,8 +4,11 @@
 
 #include "TransferElement.h"
 #include "TransferElementAbstractor.h"
+#include <initializer_list>
 
 #include <ChimeraTK/cppext/future_queue.hpp>
+
+#include <functional>
 
 namespace ChimeraTK {
 
@@ -121,7 +124,7 @@ namespace ChimeraTK {
     /**
      * Construct finalised group with the given elements. The group will behave like finalise() had already been called.
      */
-    ReadAnyGroup(std::initializer_list<TransferElementAbstractor> list);
+    ReadAnyGroup(std::initializer_list<std::reference_wrapper<TransferElementAbstractor>> list);
 
     /**
      * Construct finalised group with the given elements. The group will behave like finalise() had already been called.
@@ -412,7 +415,7 @@ namespace ChimeraTK {
 
   /********************************************************************************************************************/
 
-  inline ReadAnyGroup::ReadAnyGroup(std::initializer_list<TransferElementAbstractor> list) {
+  inline ReadAnyGroup::ReadAnyGroup(std::initializer_list<std::reference_wrapper<TransferElementAbstractor>> list) {
     for(const auto& element : list) add(element);
     finalise();
   }


### PR DESCRIPTION
In ApplicationCore we frequently pass derived objects of the
TransferElementAbstractor class with additional data members to the
ReadAnyGroup constructor. The std::initializer_list uses copy sematics,
hence the objects were sliced (i.e. copied into base class instances
which lack the additional data members). By using an
std::initialiser_list of std::reference_wrapper, only references are
copied and slicing is avoided at that point.

Note that this change mainly avoids the linter warning. The slicing at
that place was harmless, since the additional data members are not
accessed by base class functionality.
