### PR TITLE
fix missing include

### DIFF
--- a/device_backends/uio/src/UioAccess.cc
+++ b/device_backends/uio/src/UioAccess.cc
@@ -8,6 +8,7 @@
 
 #include <cerrno>
 #include <fcntl.h>
+#include <fstream>
 #include <limits>
 #include <poll.h>
 


### PR DESCRIPTION
was failing on Tumbleweed (gcc 12)
