### PR TITLE
lmap: Allow CDATA for parameters

### DIFF
--- a/device_backends/LogicalNameMapping/include/LogicalNameMapParser.h
+++ b/device_backends/LogicalNameMapping/include/LogicalNameMapParser.h
@@ -35,7 +35,7 @@ namespace ChimeraTK {
 
    protected:
     /** called inside parseFile() to parse an XML element and its sub-elements
-     * recursivly */
+     * recursively */
     void parseElement(RegisterPath currentPath, const xmlpp::Element* element,
         BackendRegisterCatalogue<LNMBackendRegisterInfo>& catalogue);
 

--- a/device_backends/LogicalNameMapping/src/LogicalNameMapParser.cc
+++ b/device_backends/LogicalNameMapping/src/LogicalNameMapParser.cc
@@ -26,6 +26,13 @@ namespace ChimeraTK {
 
     std::string value;
     for(auto& child : childList) {
+      // Check for CDATA node
+      const xmlpp::CdataNode* cdataNode = dynamic_cast<const xmlpp::CdataNode*>(child);
+      if(cdataNode) {
+        value += cdataNode->get_content();
+        continue;
+      }
+
       // check for plain text
       const xmlpp::TextNode* textNode = dynamic_cast<const xmlpp::TextNode*>(child);
       if(textNode) {
@@ -89,7 +96,7 @@ namespace ChimeraTK {
 
       // neither found: throw error
       parsingError(node,
-          "Node '" + subnodeName + "' should contain only text, references or parameters. Instead child '" +
+          "Node '" + subnodeName + "' should contain only text, CDATA sections, references or parameters. Instead child '" +
               child->get_name() + "' was found.");
     }
     return value;

--- a/tests/executables_src/testLMapMathPlugin.cpp
+++ b/tests/executables_src/testLMapMathPlugin.cpp
@@ -179,4 +179,18 @@ BOOST_AUTO_TEST_CASE(testExceptions) {
 
 /********************************************************************************************************************/
 
+BOOST_AUTO_TEST_CASE(testCDATAFormula) {
+  // missing parameter "formula"
+  ChimeraTK::Device device;
+
+  // open device with map file which parses
+  device.open("(logicalNameMap?map=mathPlugin.xlmap)");
+
+  auto acc = device.getScalarRegisterAccessor<double>("FormulaWithCdata");
+  acc.read();
+  BOOST_TEST(int(acc) == 24);
+}
+
+/********************************************************************************************************************/
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/mathPlugin.xlmap
+++ b/tests/mathPlugin.xlmap
@@ -132,4 +132,13 @@
     </plugin>
   </redirectedRegister>
 
+  <redirectedRegister name="FormulaWithCdata">
+    <targetDevice>this</targetDevice>
+    <targetRegister>SimpleScalar</targetRegister>
+    <plugin name="forceReadOnly"/>
+    <plugin name="math">
+      <parameter name="formula"><![CDATA[if ((42 > 24) & (24 < 42)) 24; else 42; ]]></parameter>
+    </plugin>
+  </redirectedRegister>
+
 </logicalNameMap>


### PR DESCRIPTION
This simplifies writing formulas containing lots of <, > and & which then don't need XML escaping