### PR TITLE
Enable 64bit io for pcie backend

### DIFF
--- a/device_backends/pcie/src/PcieBackend.cc
+++ b/device_backends/pcie/src/PcieBackend.cc
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+
+#define _FILE_OFFSET_BITS 64
+
 #include "PcieBackend.h"
 
 // the io constants and struct for the driver


### PR DESCRIPTION
The bar offsets start at bit 60 upwards, passing down the offsets
through off_t requires the 64bit variants to end up in kernel correctly
