### PR TITLE
Don't use 'included' boost test library.

### DIFF
--- a/tests/executables_src/testDummyBackend.cpp
+++ b/tests/executables_src/testDummyBackend.cpp
@@ -17,7 +17,7 @@
 #include <regex>
 
 #define BOOST_NO_EXCEPTIONS
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #undef BOOST_NO_EXCEPTIONS
 
 using namespace boost::unit_test_framework;

--- a/tests/executables_src/testExceptionDummyDevice.cc
+++ b/tests/executables_src/testExceptionDummyDevice.cc
@@ -7,7 +7,7 @@
 #include "Device.h"
 #include "ExceptionDummyBackend.h"
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 using namespace boost::unit_test_framework;
 namespace ctk = ChimeraTK;

--- a/tests/executables_src/testRebotConnectionTimeouts.cpp
+++ b/tests/executables_src/testRebotConnectionTimeouts.cpp
@@ -3,7 +3,7 @@
 
 #define BOOST_TEST_MODULE RebotConnectionTimeoutTest
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 using namespace boost::unit_test_framework;
 
 #include "Device.h"

--- a/tests/executables_src/testRebotHeartbeatCount.cpp
+++ b/tests/executables_src/testRebotHeartbeatCount.cpp
@@ -9,7 +9,7 @@
 
 #define BOOST_TEST_MODULE RebotHeartbeatCountTest
 // Only after defining the name include the unit test header.
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 using namespace boost::unit_test_framework;
 
 #include "Device.h"


### PR DESCRIPTION
The boost test library is linked. Using the included version leads to a violation of the one definition rule and causes double free corruptions.