### PR TITLE
fix g++-12 compiler warnings

### DIFF
--- a/device_backends/LogicalNameMapping/include/LNMDoubleBufferPlugin.h
+++ b/device_backends/LogicalNameMapping/include/LNMDoubleBufferPlugin.h
@@ -69,7 +69,7 @@ namespace ChimeraTK::LNMBackend {
     void replaceTransferElement(boost::shared_ptr<ChimeraTK::TransferElement> /* newElement */) override {
       // do nothing, we do not support merging of DoubleBufferAccessorDecorators
     }
-    [[nodiscard]] virtual bool mayReplaceOther(const boost::shared_ptr<TransferElement const>& other) const;
+    [[nodiscard]] bool mayReplaceOther(const boost::shared_ptr<TransferElement const>& other) const override;
 
    private:
     // we know that plugin exists at least as long as any register (of the catalogue) refers to it,

--- a/device_backends/NumericAddressedBackend/include/NumericAddressedBackendMuxedRegisterAccessor.h
+++ b/device_backends/NumericAddressedBackend/include/NumericAddressedBackendMuxedRegisterAccessor.h
@@ -25,7 +25,14 @@ namespace ChimeraTK {
 
     /** Iteration on a raw buffer with a given pitch (increment from one element to the next) in bytes */
     template<typename DATA_TYPE>
-    struct pitched_iterator : std::iterator<std::random_access_iterator_tag, DATA_TYPE> {
+    struct pitched_iterator {
+      // standard iterator traits
+      using iterator_category = std::random_access_iterator_tag;
+      using value_type = DATA_TYPE;
+      using difference_type = std::ptrdiff_t;
+      using pointer = DATA_TYPE*;
+      using reference = DATA_TYPE&;
+
       // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
       pitched_iterator(void* begin, size_t pitch) : _ptr(reinterpret_cast<std::byte*>(begin)), _pitch(pitch) {}
 


### PR DESCRIPTION
std::iterator is deprecated. Instead, the 5 iterator traits should be listed separately.﻿
