### PR TITLE
Fix warnings from Doxygen for unsupported tags

### DIFF
--- a/device_backends/LogicalNameMapping/src/LogicalNameMapParser.cc
+++ b/device_backends/LogicalNameMapping/src/LogicalNameMapParser.cc
@@ -26,7 +26,6 @@ namespace ChimeraTK {
 
     std::string value;
     for(auto& child : childList) {
-      // Check for CDATA node
       if(!child) {
         parsingError(child, "Got nullptr from parser library.");
       }

--- a/device_backends/NumericAddressedBackend/include/NumericAddress.h
+++ b/device_backends/NumericAddressedBackend/include/NumericAddress.h
@@ -10,10 +10,13 @@ namespace ChimeraTK::numeric_address {
    * by numeric addresses, instead of using register names (e.g. when no map file
    * exists). The address will form a special RegisterPath which can be used in
    * any place where a register path name is expected, if the backend supports it.
-   * The syntax is as follows: BAR/<barNumber>/<addressInBytes> -> access 4-byte
-   * register in bar <barNumber> at byte offset <addressInBytes>
-   *    BAR()/<barNumber>/<addressInBytes>*<lengthInBytes> -> access register with
-   * arbitrary length of <lengthInBytes>
+   *
+   * The syntax is as follows
+   *
+   * - `BAR()/<barNumber>/<addressInBytes>` -> access 4-byte
+   * register in bar `<barNumber>` at byte offset `<addressInBytes>`
+   * - `BAR()/<barNumber>/<addressInBytes>*<lengthInBytes>` -> access register with
+   * arbitrary length of `<lengthInBytes>`
    */
   RegisterPath BAR();
 } // namespace ChimeraTK::numeric_address


### PR DESCRIPTION
Just escape the strings as pre-formatted
