### PR TITLE
feat: put DataValidity in iostream

### DIFF
--- a/device_backends/include/TransferElement.h
+++ b/device_backends/include/TransferElement.h
@@ -43,6 +43,8 @@ namespace ChimeraTK {
     faulty /// The data is not considered valid
   };
 
+  std::ostream& operator<<(std::ostream& os, const DataValidity& validity);
+
   /**
    * @brief Used to indicate the applicable operation on a Transferelement.
    */

--- a/device_backends/src/TransferElement.cc
+++ b/device_backends/src/TransferElement.cc
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
+#include "TransferElement.h"
+
+namespace ChimeraTK {
+
+  std::ostream& operator<<(std::ostream& os, const DataValidity& validity) {
+    if(validity == DataValidity::ok) {
+      os << "ok";
+    }
+    else {
+      os << "faulty";
+    }
+    return os;
+  }
+
+}


### PR DESCRIPTION
This is also useful when comparing DataValidity objects with BOOST_TEST etc.