### PR TITLE
fix: solve asan test issues

### DIFF
--- a/tests/executables_src/testMappedImage.cc
+++ b/tests/executables_src/testMappedImage.cc
@@ -1,10 +1,9 @@
 // SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE MappedImageTest
-// Only after defining the name include the unit test header.
-#include <boost/test/included/unit_test.hpp>
-// boost unit_test needs to be included before serverBasedTestTools.h
+
 #include "Device.h"
 #include "MappedImage.h"
 #include "OneDRegisterAccessor.h"

--- a/tests/executables_src/testTypeChangingDecorator.cpp
+++ b/tests/executables_src/testTypeChangingDecorator.cpp
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
+#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE TypeChangingDecoratorTest
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <limits>
 using namespace boost::unit_test_framework;


### PR DESCRIPTION
asan saw 'double free' issues which were due to using boost unit test framework at the same time, as included variant and as linked variant. Decide for linked variant.