### PR TITLE
fix(xdma): event files opened in the wrong place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ Project(ChimeraTK-DeviceAccess)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
 set(${PROJECT_NAME}_MAJOR_VERSION 03)
-set(${PROJECT_NAME}_MINOR_VERSION 12)
+set(${PROJECT_NAME}_MINOR_VERSION 13)
 set(${PROJECT_NAME}_PATCH_VERSION 00)
 include(cmake/set_version_numbers.cmake)
 

--- a/device_backends/xdma/include/XdmaBackend.h
+++ b/device_backends/xdma/include/XdmaBackend.h
@@ -22,7 +22,8 @@ namespace ChimeraTK {
 
     std::optional<CtrlIntf> _ctrlIntf;
     std::vector<DmaIntf> _dmaChannels;
-    std::vector<EventFile> _eventFiles;
+    std::array<std::unique_ptr<EventFile>, _maxInterrupts> _eventFiles;
+    std::array<bool, _maxInterrupts> _startInterruptHandlingCalled{};
 
     const std::string _devicePath;
 


### PR DESCRIPTION
- push type accessors can be requested before opening the device
- no event file is opened if no push type accessors exist
