### PR TITLE
fix: rethrow old exceptions by math plugin after recovery

### DIFF
--- a/device_backends/LogicalNameMapping/include/internal/LNMMathPluginFormulaHelper.h
+++ b/device_backends/LogicalNameMapping/include/internal/LNMMathPluginFormulaHelper.h
@@ -31,10 +31,6 @@ namespace ChimeraTK::LNMBackend {
     // This function updates all parameter accessors and return their worst validity
     [[nodiscard]] ChimeraTK::DataValidity updateParameters();
 
-    // Clear the queues of all parameter accessors. Called in openHook to prevent old exceptions on the queues to be
-    // rethrown after re-opening the device.
-    void clearParameterQueues();
-
     // This function updates result in target based on latest values of parameter accessors and lastMainValue
     void updateResult(ChimeraTK::VersionNumber versionNumber);
 

--- a/device_backends/LogicalNameMapping/src/LNMBackendVariableAccessor.cc
+++ b/device_backends/LogicalNameMapping/src/LNMBackendVariableAccessor.cc
@@ -232,8 +232,12 @@ namespace ChimeraTK {
         auto& vtEntry = boost::fusion::at_key<decltype(arg)>(lnmVariable.valueTable.table);
         for(size_t i = 0; i < this->buffer_2D[0].size(); ++i) {
           this->buffer_2D[0][i] = userTypeToUserType<UserType>(vtEntry.latestValue[i + _wordOffsetInRegister]);
-          this->_dataValidity = vtEntry.latestValidity;
         }
+        this->_dataValidity = vtEntry.latestValidity;
+        // Note: passing through the version number also for push-type variables is essential for the MathPlugin (cf.
+        // MathPluginFormulaHelper::checkAllParametersWritten()) and does not violate the spec (spec says we should not
+        // be able to see whether there was an update, which still is impossible since updates can have the same
+        // version number as before).
         this->_versionNumber = vtEntry.latestVersion;
       });
     }

--- a/device_backends/LogicalNameMapping/src/LNMBackendVariableAccessor.cc
+++ b/device_backends/LogicalNameMapping/src/LNMBackendVariableAccessor.cc
@@ -234,8 +234,8 @@ namespace ChimeraTK {
           this->buffer_2D[0][i] = userTypeToUserType<UserType>(vtEntry.latestValue[i + _wordOffsetInRegister]);
           this->_dataValidity = vtEntry.latestValidity;
         }
+        this->_versionNumber = vtEntry.latestVersion;
       });
-      this->_versionNumber = {};
     }
     else {
       // push-type read transfer: received value is in _queueValue (cf. readQueue continuation in constructor)

--- a/device_backends/LogicalNameMapping/src/LNMMathPlugin.cc
+++ b/device_backends/LogicalNameMapping/src/LNMMathPlugin.cc
@@ -195,8 +195,8 @@ namespace ChimeraTK::LNMBackend {
     }
 
     for(const auto& acc : _accessorMap) {
-      // push-type accessors: version number check will notice whether valid data has been provided after open
-      // poll-type accessors: version number check always succeeds since readLatest returns new version numbers
+      // Version number check will notice whether valid data has been provided after open. This works for both push and
+      // poll, since the LNM variables always pass through the version number from the write operation to the read.
       if(acc.second->getVersionNumber() <= _backend->getVersionOnOpen()) {
         return false;
       }

--- a/device_backends/LogicalNameMapping/src/LogicalNameMappingBackend.cc
+++ b/device_backends/LogicalNameMapping/src/LogicalNameMappingBackend.cc
@@ -371,25 +371,6 @@ namespace ChimeraTK {
                 std::terminate();
               }
             }
-            // also give MathPlugin instances which are using the variable as push-parameter the chance to update
-            for(auto* mp : lnmVariable.usingFormulas) {
-              if(mp->_hasPushParameter) {
-                auto h = mp->getFormulaHelper({});
-                if(h) {
-                  // accessor to formula result or parameter exists
-                  try {
-                    h->updateResult(vtEntry.latestVersion);
-                  }
-                  // the only exception that updateResult may throw is logic_error; we print the message & terminate
-                  // since termination would be anyway be enforced by this function being 'noexcept',
-                  // but we also want the message for debugging purposes.
-                  catch(logic_error& e) {
-                    std::cout << "logic_error in activateAsyncRead: " << e.what() << std::endl;
-                    std::terminate();
-                  }
-                }
-              }
-            }
           });
         }
         catch(std::bad_cast& e) {

--- a/device_backends/include/UnifiedBackendTest.h
+++ b/device_backends/include/UnifiedBackendTest.h
@@ -49,7 +49,8 @@ namespace ChimeraTK {
       TestCapability _writeNeverLosesData = TestCapability::unspecified,
       TestCapability _testWriteOnly = TestCapability::disabled, TestCapability _testReadOnly = TestCapability::disabled,
       TestCapability _testRawTransfer = TestCapability::unspecified,
-      TestCapability _testCatalogue = TestCapability::enabled>
+      TestCapability _testCatalogue = TestCapability::enabled,
+      TestCapability _setRemoteValueIncrementsVersion = TestCapability::enabled>
   struct TestCapabilities {
     constexpr TestCapabilities() = default;
 
@@ -59,57 +60,66 @@ namespace ChimeraTK {
     /// handed out by real backends must always support this, to the syncReadTests capability should be enable for all
     /// backend tests.
     constexpr TestCapabilities<TestCapability::disabled, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
-        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue>
+        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         disableSyncRead() const {
       return {};
     }
 
     /// See setForceDataLossWrite() function in the register descriptor.
     constexpr TestCapabilities<_syncRead, TestCapability::enabled, _asyncReadInconsistency, _switchReadOnly,
-        _switchWriteOnly, TestCapability::disabled, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue>
+        _switchWriteOnly, TestCapability::disabled, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         enableForceDataLossWrite() const {
       static_assert(_writeNeverLosesData != TestCapability::enabled,
           "enableTestWriteNeverLosesData() and enableForceDataLossWrite() are mutually exclusive.");
       return {};
     }
     constexpr TestCapabilities<_syncRead, TestCapability::disabled, _asyncReadInconsistency, _switchReadOnly,
-        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue>
+        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         disableForceDataLossWrite() const {
       return {};
     }
 
     /// See forceAsyncReadInconsistency() function in the register descriptor.
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, TestCapability::enabled, _switchReadOnly,
-        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue>
+        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         enableAsyncReadInconsistency() const {
       return {};
     }
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, TestCapability::disabled, _switchReadOnly,
-        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue>
+        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         disableAsyncReadInconsistency() const {
       return {};
     }
 
     /// See switchReadOnly() function in the register descriptor.
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, TestCapability::enabled,
-        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue>
+        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         enableSwitchReadOnly() const {
       return {};
     }
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, TestCapability::disabled,
-        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue>
+        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         disableSwitchReadOnly() const {
       return {};
     }
 
     /// See switchWriteOnly() function in the register descriptor.
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
-        TestCapability::enabled, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue>
+        TestCapability::enabled, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         enableSwitchWriteOnly() const {
       return {};
     }
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
-        TestCapability::disabled, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue>
+        TestCapability::disabled, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         disableSwitchWriteOnly() const {
       return {};
     }
@@ -118,14 +128,16 @@ namespace ChimeraTK {
     /// writes is performed and no data loss must be reported.
     /// Mutually exclusive with enableForceDataLossWrite().
     constexpr TestCapabilities<_syncRead, TestCapability::disabled, _asyncReadInconsistency, _switchReadOnly,
-        _switchWriteOnly, TestCapability::enabled, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue>
+        _switchWriteOnly, TestCapability::enabled, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         enableTestWriteNeverLosesData() const {
       static_assert(_forceDataLossWrite != TestCapability::enabled,
           "enableTestWriteNeverLosesData() and enableForceDataLossWrite() are mutualy exclusive.");
       return {};
     }
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
-        _switchWriteOnly, TestCapability::disabled, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue>
+        _switchWriteOnly, TestCapability::disabled, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         disableTestWriteNeverLosesData() const {
       return {};
     }
@@ -133,13 +145,13 @@ namespace ChimeraTK {
     /// Enable/disable testing only write operations, even if the register is readable
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
         _switchWriteOnly, _writeNeverLosesData, TestCapability::enabled, _testReadOnly, _testRawTransfer,
-        _testCatalogue>
+        _testCatalogue, _setRemoteValueIncrementsVersion>
         enableTestWriteOnly() const {
       return {};
     }
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
         _switchWriteOnly, _writeNeverLosesData, TestCapability::disabled, _testReadOnly, _testRawTransfer,
-        _testCatalogue>
+        _testCatalogue, _setRemoteValueIncrementsVersion>
         disableTestWriteOnly() const {
       return {};
     }
@@ -147,25 +159,27 @@ namespace ChimeraTK {
     /// Enable/disable testing only read operations, even if the register is readable
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
         _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, TestCapability::enabled, _testRawTransfer,
-        _testCatalogue>
+        _testCatalogue, _setRemoteValueIncrementsVersion>
         enableTestReadOnly() const {
       return {};
     }
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
         _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, TestCapability::disabled, _testRawTransfer,
-        _testCatalogue>
+        _testCatalogue, _setRemoteValueIncrementsVersion>
         disableTestReadOnly() const {
       return {};
     }
 
     /// Enable/disable testing the raw accessors
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
-        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, TestCapability::disabled, _testCatalogue>
+        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, TestCapability::disabled, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         disableTestRawTransfer() const {
       return {};
     }
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
-        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, TestCapability::enabled, _testCatalogue>
+        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, TestCapability::enabled, _testCatalogue,
+        _setRemoteValueIncrementsVersion>
         enableTestRawTransfer() const {
       return {};
     }
@@ -173,14 +187,28 @@ namespace ChimeraTK {
     /// Enable/disable testing of catalogue content
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
         _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer,
-        TestCapability::disabled>
+        TestCapability::disabled, _setRemoteValueIncrementsVersion>
         disableTestCatalogue() const {
       return {};
     }
     constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
         _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer,
-        TestCapability::enabled>
+        TestCapability::enabled, _setRemoteValueIncrementsVersion>
         enableTestCatalogue() const {
+      return {};
+    }
+
+    /// Enable/disable testing of version number increment in read operations after setRemoteValue
+    constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
+        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        TestCapability::disabled>
+        disableSetRemoteValueIncrementsVersion() const {
+      return {};
+    }
+    constexpr TestCapabilities<_syncRead, _forceDataLossWrite, _asyncReadInconsistency, _switchReadOnly,
+        _switchWriteOnly, _writeNeverLosesData, _testWriteOnly, _testReadOnly, _testRawTransfer, _testCatalogue,
+        TestCapability::enabled>
+        enableSetRemoteValueIncrementsVersion() const {
       return {};
     }
 
@@ -194,6 +222,7 @@ namespace ChimeraTK {
     static constexpr TestCapability testReadOnly{_testReadOnly};
     static constexpr TestCapability testRawTransfer{_testRawTransfer};
     static constexpr TestCapability testCatalogue{_testCatalogue};
+    static constexpr TestCapability setRemoteValueIncrementsVersion{_setRemoteValueIncrementsVersion};
   };
 
   /**
@@ -2586,6 +2615,7 @@ namespace ChimeraTK {
     // synchronous read
     boost::mpl::for_each<VECTOR_OF_REGISTERS_T>([&](auto x) {
       if(!this->isRead(x)) return;
+      if(x.capabilities.setRemoteValueIncrementsVersion == TestCapability::disabled) return;
       typedef typename decltype(x)::minimumUserType UserType;
       auto registerName = x.path();
       VersionNumber someVersion{nullptr};

--- a/tests/executables_src/testLMapBackendUnified.cpp
+++ b/tests/executables_src/testLMapBackendUnified.cpp
@@ -193,7 +193,8 @@ struct ScalarRegisterDescriptorBase : OneDRegisterDescriptorBase<Derived> {
 template<typename Derived>
 struct ConstantRegisterDescriptorBase : RegisterDescriptorBase<Derived> {
   using RegisterDescriptorBase<Derived>::derived;
-  static constexpr auto capabilities = RegisterDescriptorBase<Derived>::capabilities.disableTestRawTransfer();
+  static constexpr auto capabilities =
+      RegisterDescriptorBase<Derived>::capabilities.disableTestRawTransfer().disableSetRemoteValueIncrementsVersion();
 
   size_t nChannels() { return 1; }
   bool isWriteable() { return false; }

--- a/tests/executables_src/testLMapMathPluginPushPars.cc
+++ b/tests/executables_src/testLMapMathPluginPushPars.cc
@@ -112,8 +112,7 @@ BOOST_AUTO_TEST_CASE(testPushPars) {
     writeCount++;
     BOOST_TEST(targetWriteCount() == writeCount);
 
-    // user expectation will be that write-behavior does not depend on when we call activateAsyncRead,
-    // so test that update is retrieved even if it's called last
+    // write-behavior does not depend on whether or when we call activateAsyncRead
     logicalDevice.close();
     logicalDevice.open();
     accTarget = 0;
@@ -121,14 +120,13 @@ BOOST_AUTO_TEST_CASE(testPushPars) {
     writeCount++;                                 // direct write from test also counts
     BOOST_TEST(targetWriteCount() == writeCount); // sanity check (that we are counting correctly)
     accMathWrite = 7;
-    accMathWrite.write();
+    accMathWrite.write(); // not all parameters written after open -> no target write
     pushPar = 6;
     pushPar.write();
+    writeCount++;
     BOOST_TEST(int(accTarget) == 0);
     BOOST_TEST(targetWriteCount() == writeCount);
-    logicalDevice.activateAsyncRead();
-    // activateAsyncRead should have triggered single write
-    writeCount++;
+    logicalDevice.activateAsyncRead(); // does not trigger target write
     BOOST_TEST(targetWriteCount() == writeCount);
     accTarget.read();
     BOOST_TEST(int(accTarget) == 10 * pushPar + accMathWrite);
@@ -157,9 +155,9 @@ BOOST_AUTO_TEST_CASE(testPushPars) {
     pushPar.write();
     pushPar2.write();
     accMathWrite2.write();
+    writeCount2++;
     BOOST_TEST(targetWriteCount2() == writeCount2);
     logicalDevice.activateAsyncRead();
-    writeCount2++;
     BOOST_TEST(int(accTarget2) == 200 * pushPar2 + 20 * pushPar + 2 * accMathWrite2);
     BOOST_TEST(targetWriteCount2() == writeCount2);
   }


### PR DESCRIPTION
This replaces the earlier hotfix with a better implementation.

As a (positive) side effect of the new fix, push-type parameters of math plugins now work independently of the async read activation state.