### PR TITLE
feat: obtain minimum data type from DataDescriptor

### DIFF
--- a/device/include/DataDescriptor.h
+++ b/device/include/DataDescriptor.h
@@ -109,6 +109,11 @@ namespace ChimeraTK {
      */
     [[nodiscard]] DataType transportLayerDataType() const;
 
+    /**
+     * Get the minimum data type required to represent the described data type in the host CPU
+     */
+    [[nodiscard]] DataType minimumDataType() const;
+
     bool operator==(const DataDescriptor& other) const;
     bool operator!=(const DataDescriptor& other) const;
 

--- a/device/src/DataDescriptor.cpp
+++ b/device/src/DataDescriptor.cpp
@@ -138,6 +138,58 @@ namespace ChimeraTK {
   }
 
   /********************************************************************************************************************/
+
+  DataType DataDescriptor::minimumDataType() const {
+    if(fundamentalType() == DataDescriptor::FundamentalType::numeric) {
+      if(isIntegral()) {
+        if(isSigned()) {
+          if(nDigits() > 11) {
+            return typeid(int64_t);
+          }
+          if(nDigits() > 6) {
+            return typeid(int32_t);
+          }
+          if(nDigits() > 4) {
+            return typeid(int16_t);
+          }
+          return typeid(int8_t);
+        }
+        if(nDigits() > 10) {
+          return typeid(uint64_t);
+        }
+        if(nDigits() > 5) {
+          return typeid(uint32_t);
+        }
+        if(nDigits() > 3) {
+          return typeid(uint16_t);
+        }
+        return typeid(uint8_t);
+      }
+      // fractional:
+      // Maximum number of decimal digits to display a float without loss in non-exponential display, including
+      // sign, leading 0, decimal dot and one extra digit to avoid rounding issues (hence the +4).
+      // This computation matches the one performed in the NumericAddressedBackend catalogue.
+      size_t floatMaxDigits = 4 +
+          size_t(std::max(
+              std::log10(std::numeric_limits<float>::max()), -std::log10(std::numeric_limits<float>::denorm_min())));
+      if(nDigits() > floatMaxDigits) {
+        return typeid(double);
+      }
+      return typeid(float);
+    }
+    if(fundamentalType() == DataDescriptor::FundamentalType::boolean) {
+      return typeid(ChimeraTK::Boolean);
+    }
+    if(fundamentalType() == DataDescriptor::FundamentalType::string) {
+      return typeid(std::string);
+    }
+    if(fundamentalType() == DataDescriptor::FundamentalType::nodata) {
+      return typeid(ChimeraTK::Void);
+    }
+    return {};
+  }
+
+  /********************************************************************************************************************/
   /********************************************************************************************************************/
 
   std::ostream& operator<<(std::ostream& stream, const DataDescriptor::FundamentalType& fundamentalType) {

--- a/util/include/SupportedUserTypes.h
+++ b/util/include/SupportedUserTypes.h
@@ -819,6 +819,40 @@ namespace ChimeraTK {
       }
     }
 
+    /** Return std::type_info representation of the data type */
+    [[nodiscard]] inline const std::type_info& getAsTypeInfo() const {
+      switch(_value) {
+        case int8:
+          return typeid(int8_t);
+        case uint8:
+          return typeid(uint8_t);
+        case int16:
+          return typeid(int16_t);
+        case uint16:
+          return typeid(uint16_t);
+        case int32:
+          return typeid(int32_t);
+        case uint32:
+          return typeid(uint32_t);
+        case int64:
+          return typeid(int64_t);
+        case uint64:
+          return typeid(uint64_t);
+        case float32:
+          return typeid(float);
+        case float64:
+          return typeid(double);
+        case string:
+          return typeid(std::string);
+        case Boolean:
+          return typeid(ChimeraTK::Boolean);
+        case Void:
+          return typeid(ChimeraTK::Void);
+        case none:
+          return typeid(nullptr_t);
+      }
+    }
+
    protected:
     TheType _value;
   };


### PR DESCRIPTION
This code is basically moved from ApplicationCore to
make it generally available (Python bindings need it
as well)