### PR TITLE
fix: structured bind in lambdas

### DIFF
--- a/device_backends/LogicalNameMapping/src/LogicalNameMappingBackend.cc
+++ b/device_backends/LogicalNameMapping/src/LogicalNameMappingBackend.cc
@@ -69,7 +69,8 @@ namespace ChimeraTK {
 
     // update versions of constants
     auto versionForConstants = ChimeraTK::VersionNumber{}; // needs to be bigger than _versionOnOpen
-    for(auto& [name, variable] : _variables) {
+    for(auto& nameAndVar : _variables) {
+      auto& variable = nameAndVar.second;
       if(variable.isConstant) {
         std::lock_guard<std::mutex> lk(variable.valueTable_mutex);
         ChimeraTK::callForType(variable.valueType, [&](auto v) {


### PR DESCRIPTION
Clang does not support the use of variables from a structured bind
in lambdas yet.
