### PR TITLE
Looking for libxml++-5.0 before falling back to libxml++-2.6.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,13 @@ FIND_PACKAGE(exprtk 01.04 REQUIRED)
 FIND_PACKAGE(nlohmann_json 03.07 REQUIRED)
 
 FIND_PACKAGE(PkgConfig REQUIRED)
-set(LIBXML++_VERSION "libxml++-2.6")
-PKG_CHECK_MODULES(LibXML++ REQUIRED IMPORTED_TARGET ${LIBXML++_VERSION})
+set(LIBXML++_VERSION "libxml++-5.0")
+PKG_CHECK_MODULES(LibXML++ IMPORTED_TARGET ${LIBXML++_VERSION})
+
+if (NOT DEFINED LIBXML++_FOUND)
+  set(LIBXML++_VERSION "libxml++-2.6")
+  PKG_CHECK_MODULES(LibXML++ REQUIRED IMPORTED_TARGET ${LIBXML++_VERSION})
+endif ()
 
 # The PCIe backend can only be built on Linux, so we define a variable here that
 # we can then use in other places.


### PR DESCRIPTION
As pointed out in #193, the usage of libxml++-5.0 gives no problems.
I have successfully tested the usage of a statically linked version libxml++-5.0, so why not use it if it is available in the system?

