### PR TITLE
fix failing test

### DIFF
--- a/device_backends/DummyBackend/include/DummyInterruptTriggerAccessor.h
+++ b/device_backends/DummyBackend/include/DummyInterruptTriggerAccessor.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "NDRegisterAccessor.h"
-#include "NumericAddressedBackend.h"
 
 #include <utility>
 

--- a/device_backends/DummyBackend/include/ExceptionDummyBackend.h
+++ b/device_backends/DummyBackend/include/ExceptionDummyBackend.h
@@ -69,7 +69,7 @@ namespace ChimeraTK {
 
         acc = decorator;
       }
-      else {
+      else if(acc->isReadable()) {
         // decorate all poll-type variable so returned validity of the data can be controlled
         auto decorator = boost::make_shared<ExceptionDummyPollDecorator<UserType>>(
             acc, boost::dynamic_pointer_cast<ExceptionDummy>(this->shared_from_this()));

--- a/device_backends/include/UnifiedBackendTest.h
+++ b/device_backends/include/UnifiedBackendTest.h
@@ -3654,15 +3654,6 @@ namespace ChimeraTK {
       auto registerName = x.path();
       std::cout << "... registerName = " << registerName << std::endl;
 
-      // workaround for DUMMY_WRITABLE not having information in the catalogue yet
-      if(std::string(registerName).find("DUMMY_WRITEABLE") != std::string::npos) {
-        return;
-      }
-
-      if(std::string(registerName).find("DUMMY_INTERRUPT_") != std::string::npos) {
-        return;
-      }
-
       auto registerInfo = d.getRegisterCatalogue().getRegister(registerName);
       auto accessor = d.getScalarRegisterAccessor<UserType>(registerName);
 

--- a/device_backends/src/DummyInterruptTriggerAccessor.cc
+++ b/device_backends/src/DummyInterruptTriggerAccessor.cc
@@ -29,7 +29,7 @@ namespace ChimeraTK {
 
     NDRegisterAccessor<UserType>::buffer_2D.resize(1);
     NDRegisterAccessor<UserType>::buffer_2D[0].resize(1);
-    NDRegisterAccessor<UserType>::buffer_2D[0][0] = numericToUserType<UserType>(1);
+    NDRegisterAccessor<UserType>::buffer_2D[0][0] = numericToUserType<UserType>(0);
   }
 
   /********************************************************************************************************************/

--- a/tests/executables_src/testUioBackendUnified.cpp
+++ b/tests/executables_src/testUioBackendUnified.cpp
@@ -129,7 +129,7 @@ RawUioAccess::~RawUioAccess() {
 
 void RawUioAccess::sendInterrupt() const {
   static int enable{1};
-  ::write(_uioProcFd, &enable, sizeof(enable));
+  std::ignore = ::write(_uioProcFd, &enable, sizeof(enable));
 }
 
 /**********************************************************************************************************************/


### PR DESCRIPTION
- fix: dummy bugs
testDummyBackendUnified was failing since the DummyInterruptTriggerAccessor was correctly reporting that it is not readable.
The failure was due to a bug in the ExceptionDummyBackend. The decorator of the ExceptionDummyBackend was also masking a wrong value
in the user buffer of the DummyInterruptTriggerAccessor.

﻿- fix(UnifiedBackendTest): catalogue test disabled for dummy accessors
The DummyInterruptTriggerAccessor reporting the wrong readability was not detected because the Unified backend test was not sensitive.
The workaround has been removed since the dummy accessors are in the catalogue since some time.

- fix: compiler warning
