### PR TITLE
fix: Provide explicit template specialisations

### DIFF
--- a/backends/DummyBackend/include/DummyBackendBase.h
+++ b/backends/DummyBackend/include/DummyBackendBase.h
@@ -37,7 +37,7 @@ namespace ChimeraTK {
     size_t minimumTransferAlignment([[maybe_unused]] uint64_t bar) const override;
 
     // Declare that we are going to override getRegisterAccessor_impl
-    DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(getRegisterAccessor_impl,
+    DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(NumericAddressedBackend, getRegisterAccessor_impl,
         boost::shared_ptr<NDRegisterAccessor<T>>(const RegisterPath&, size_t, size_t, AccessModeFlags));
 
     /** Simulate the arrival of an interrupt. For all push-type accessors which have been created

--- a/backends/DummyBackend/include/DummyBackendBase.h
+++ b/backends/DummyBackend/include/DummyBackendBase.h
@@ -36,6 +36,10 @@ namespace ChimeraTK {
 
     size_t minimumTransferAlignment([[maybe_unused]] uint64_t bar) const override;
 
+    // Declare that we are going to override getRegisterAccessor_impl
+    DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(getRegisterAccessor_impl,
+        boost::shared_ptr<NDRegisterAccessor<T>>(const RegisterPath&, size_t, size_t, AccessModeFlags));
+
     /** Simulate the arrival of an interrupt. For all push-type accessors which have been created
      *  for that particular interrupt number, the data will be read out
      *  through a synchronous accessor and pushed into the data transport queues of the asynchronous
@@ -76,33 +80,8 @@ namespace ChimeraTK {
 
     /// Specific override which allows to create "DUMMY_INTEERRUPT_X" accessors
     template<typename UserType>
-    boost::shared_ptr<NDRegisterAccessor<UserType>> getRegisterAccessor_impl(const RegisterPath& registerPathName,
-        size_t numberOfWords, size_t wordOffsetInRegister, AccessModeFlags flags) {
-      // First check if the request is for one of the special DUMMY_INTEERRUPT_X registers. if so, early return
-      // this special accessor.
-      if(registerPathName.startsWith("DUMMY_INTERRUPT_")) {
-        bool interruptFound;
-        uint32_t interrupt;
-
-        auto* dummyCatalogue = dynamic_cast<DummyBackendRegisterCatalogue*>(_registerMapPointer.get());
-        assert(dummyCatalogue);
-        std::tie(interruptFound, interrupt) = dummyCatalogue->extractControllerInterrupt(registerPathName);
-        if(!interruptFound) {
-          throw ChimeraTK::logic_error("Unknown dummy interrupt " + registerPathName);
-        }
-
-        // Delegate the other parameters down to the accessor which will throw accordingly, to satisfy the specification
-        // Since the accessor will keep a shared pointer to the backend, we can safely capture "this"
-        auto d = new DummyInterruptTriggerAccessor<UserType>(
-            shared_from_this(), [this, interrupt]() { return triggerInterrupt(interrupt); }, registerPathName,
-            numberOfWords, wordOffsetInRegister, flags);
-
-        return boost::shared_ptr<NDRegisterAccessor<UserType>>(d);
-      }
-
-      return NumericAddressedBackend::getRegisterAccessor_impl<UserType>(
-          registerPathName, numberOfWords, wordOffsetInRegister, flags);
-    }
+    boost::shared_ptr<NDRegisterAccessor<UserType>> getRegisterAccessor_impl(
+        const RegisterPath& registerPathName, size_t numberOfWords, size_t wordOffsetInRegister, AccessModeFlags flags);
 
     /**
      * @brief Backward compatibility: Leftover from the time when the dummy managed it's own map

--- a/backends/DummyBackend/include/ExceptionDummyBackend.h
+++ b/backends/DummyBackend/include/ExceptionDummyBackend.h
@@ -24,7 +24,7 @@ namespace ChimeraTK {
    public:
     explicit ExceptionDummy(std::string const& mapFileName);
 
-    DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(getRegisterAccessor_impl,
+    DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(DummyBackendBase, getRegisterAccessor_impl,
         boost::shared_ptr<NDRegisterAccessor<T>>(const RegisterPath&, size_t, size_t, AccessModeFlags));
 
     static boost::shared_ptr<DeviceBackend> createInstance(

--- a/backends/DummyBackend/src/ExceptionDummyBackend.cc
+++ b/backends/DummyBackend/src/ExceptionDummyBackend.cc
@@ -90,7 +90,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   ExceptionDummy::ExceptionDummy(const std::string& mapFileName) : DummyBackend(mapFileName) {
-    OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(getRegisterAccessor_impl);
+    OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(DummyBackendBase, getRegisterAccessor_impl);
   }
 
   /********************************************************************************************************************/
@@ -179,7 +179,7 @@ namespace ChimeraTK {
       path--; // remove last component
     }
 
-    auto acc = CALL_BASE_FUNCTION_TEMPLATE(
+    auto acc = CALL_BASE_FUNCTION_TEMPLATE(DummyBackendBase,
         getRegisterAccessor_impl, UserType, path, numberOfWords, wordOffsetInRegister, flags);
     if(pushRead) {
       std::unique_lock<std::mutex> lk(_pushDecoratorsMutex);

--- a/backends/DummyBackend/src/ExceptionDummyBackend.cc
+++ b/backends/DummyBackend/src/ExceptionDummyBackend.cc
@@ -179,8 +179,8 @@ namespace ChimeraTK {
       path--; // remove last component
     }
 
-    auto acc = CALL_BASE_FUNCTION_TEMPLATE(DummyBackendBase,
-        getRegisterAccessor_impl, UserType, path, numberOfWords, wordOffsetInRegister, flags);
+    auto acc = CALL_BASE_FUNCTION_TEMPLATE(
+        DummyBackendBase, getRegisterAccessor_impl, UserType, path, numberOfWords, wordOffsetInRegister, flags);
     if(pushRead) {
       std::unique_lock<std::mutex> lk(_pushDecoratorsMutex);
 

--- a/include/NumericAddressedBackend.h
+++ b/include/NumericAddressedBackend.h
@@ -158,10 +158,6 @@ namespace ChimeraTK {
     /// mutex for protecting unaligned access
     std::mutex _unalignedAccess;
 
-    template<typename UserType>
-    boost::shared_ptr<NDRegisterAccessor<UserType>> getRegisterAccessor_impl(
-        const RegisterPath& registerPathName, size_t numberOfWords, size_t wordOffsetInRegister, AccessModeFlags flags);
-
     friend NumericAddressedLowLevelTransferElement;
     friend TriggeredPollDistributor;
 
@@ -169,6 +165,10 @@ namespace ChimeraTK {
     friend class NumericAddressedBackendMuxedRegisterAccessor;
 
    private:
+    template<typename UserType>
+    boost::shared_ptr<NDRegisterAccessor<UserType>> getRegisterAccessor_impl(
+        const RegisterPath& registerPathName, size_t numberOfWords, size_t wordOffsetInRegister, AccessModeFlags flags);
+
     // internal helper function to get the a synchronous accessor, which is also needed by the asynchronous version
     // internally, but is not given out
     template<typename UserType>

--- a/include/VirtualFunctionTemplate.h
+++ b/include/VirtualFunctionTemplate.h
@@ -29,8 +29,10 @@
  * filled differently depending on whether you want to (be able to) call the base class's
  * implementation or not:
  *
- * <ul> If you do not care about the base implementation, use the macros DEFINE_VIRTUAL_FUNCTION_TEMPLATE_VTABLE_FILLER
- * and FILL_VIRTUAL_FUNCTION_TEMPLATE_VTABLE. <ul> If you want to be able to delegate to the base implementation, use
+ * <ul> If you do not care about the base implementation, use the macros
+ * DEFINE_VIRTUAL_FUNCTION_TEMPLATE_VTABLE_FILLER
+ * and FILL_VIRTUAL_FUNCTION_TEMPLATE_VTABLE.
+ * <ul> If you want to be able to delegate to the base implementation, use
  * the macros DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE and OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE. To chain up to the base
  * implementation, use the macro CALL_BASE_FUNCTION_TEMPLATE
  *
@@ -74,7 +76,7 @@
  *  OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE
  */
 #define CALL_BASE_FUNCTION_TEMPLATE(BaseClass, functionName, templateArgument, ...)                                    \
-boost::fusion::at_key<templateArgument>(BaseClass##functionName##_vtable.table)(__VA_ARGS__)
+  boost::fusion::at_key<templateArgument>(BaseClass##functionName##_vtable.table)(__VA_ARGS__)
 
 /** Fill the vtable of a virtual function template defined with
  * DEFINE_VIRTUAL_FUNCTION_TEMPLATE. Use this macro inside the constructor of

--- a/include/VirtualFunctionTemplate.h
+++ b/include/VirtualFunctionTemplate.h
@@ -53,8 +53,8 @@
  *
  * Semantics apply as in DEFINE_VIRTUAL_FUNCTION_TEMPLATE.
  */
-#define DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(functionName, ...)                                                     \
-  DEFINE_VIRTUAL_FUNCTION_TEMPLATE_VTABLE(functionName##_base, __VA_ARGS__)
+#define DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(BaseClass, functionName, ...)                                          \
+  DEFINE_VIRTUAL_FUNCTION_TEMPLATE_VTABLE(BaseClass##functionName, __VA_ARGS__)
 
 /** Execute the virtual function template call using the vtable defined with the
  *  DEFINE_VIRTUAL_FUNCTION_TEMPLATE_VTABLE macro. It is recommended to put this
@@ -73,8 +73,8 @@
  *  The function must have been overriden by DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE and
  *  OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE
  */
-#define CALL_BASE_FUNCTION_TEMPLATE(functionName, templateArgument, ...)                                               \
-  boost::fusion::at_key<templateArgument>(functionName##_base_vtable.table)(__VA_ARGS__)
+#define CALL_BASE_FUNCTION_TEMPLATE(BaseClass, functionName, templateArgument, ...)                                    \
+boost::fusion::at_key<templateArgument>(BaseClass##functionName##_vtable.table)(__VA_ARGS__)
 
 /** Fill the vtable of a virtual function template defined with
  * DEFINE_VIRTUAL_FUNCTION_TEMPLATE. Use this macro inside the constructor of
@@ -88,10 +88,10 @@
 /** Save the old vtable to be accessible by CALL_BASE_FUNCTION_TEMPLATE and overwrite it with the
  *  new implementation.
  */
-#define OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(functionName)                                                               \
+#define OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(BaseClass, functionName)                                                    \
   do {                                                                                                                 \
     /* Copy the old vtable into _base before filling it with the new implementation */                                 \
-    ChimeraTK::for_each(functionName##_base_vtable.table, [&](auto& pair) {                                            \
+    ChimeraTK::for_each(BaseClass##functionName##_vtable.table, [&](auto& pair) {                                      \
       typedef typename std::remove_reference<decltype(pair)>::type::first_type VTableFillerUserType;                   \
       pair.second = (boost::fusion::at_key<VTableFillerUserType>(functionName##_vtable.table));                        \
     });                                                                                                                \

--- a/src/DummyBackendBase.cc
+++ b/src/DummyBackendBase.cc
@@ -8,7 +8,7 @@ namespace ChimeraTK {
   DummyBackendBase::DummyBackendBase(std::string const& mapFileName)
   : NumericAddressedBackend(mapFileName, std::make_unique<DummyBackendRegisterCatalogue>()) {
     // Copy the old vtable
-    OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(getRegisterAccessor_impl);
+    OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(NumericAddressedBackend, getRegisterAccessor_impl);
   }
 
   size_t DummyBackendBase::minimumTransferAlignment([[maybe_unused]] uint64_t bar) const {
@@ -64,7 +64,7 @@ namespace ChimeraTK {
     }
 
     // Chain up to to the base class using the previously stored function
-    return CALL_BASE_FUNCTION_TEMPLATE(
+    return CALL_BASE_FUNCTION_TEMPLATE(NumericAddressedBackend,
         getRegisterAccessor_impl, UserType, registerPathName, numberOfWords, wordOffsetInRegister, flags);
   }
 

--- a/src/DummyBackendBase.cc
+++ b/src/DummyBackendBase.cc
@@ -7,7 +7,8 @@ namespace ChimeraTK {
 
   DummyBackendBase::DummyBackendBase(std::string const& mapFileName)
   : NumericAddressedBackend(mapFileName, std::make_unique<DummyBackendRegisterCatalogue>()) {
-    FILL_VIRTUAL_FUNCTION_TEMPLATE_VTABLE(getRegisterAccessor_impl);
+    // Copy the old vtable
+    OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(getRegisterAccessor_impl);
   }
 
   size_t DummyBackendBase::minimumTransferAlignment([[maybe_unused]] uint64_t bar) const {
@@ -35,6 +36,36 @@ namespace ChimeraTK {
     if(sizeInBytes % sizeof(int32_t)) {
       throw ChimeraTK::logic_error("Read/write size has to be a multiple of 4");
     }
+  }
+
+  template<typename UserType>
+  boost::shared_ptr<NDRegisterAccessor<UserType>> DummyBackendBase::getRegisterAccessor_impl(
+      const RegisterPath& registerPathName, size_t numberOfWords, size_t wordOffsetInRegister, AccessModeFlags flags) {
+    // First check if the request is for one of the special DUMMY_INTEERRUPT_X registers. if so, early return
+    // this special accessor.
+    if(registerPathName.startsWith("DUMMY_INTERRUPT_")) {
+      bool interruptFound;
+      uint32_t interrupt;
+
+      auto* dummyCatalogue = dynamic_cast<DummyBackendRegisterCatalogue*>(_registerMapPointer.get());
+      assert(dummyCatalogue);
+      std::tie(interruptFound, interrupt) = dummyCatalogue->extractControllerInterrupt(registerPathName);
+      if(!interruptFound) {
+        throw ChimeraTK::logic_error("Unknown dummy interrupt " + registerPathName);
+      }
+
+      // Delegate the other parameters down to the accessor which will throw accordingly, to satisfy the specification
+      // Since the accessor will keep a shared pointer to the backend, we can safely capture "this"
+      auto d = new DummyInterruptTriggerAccessor<UserType>(
+          shared_from_this(), [this, interrupt]() { return triggerInterrupt(interrupt); }, registerPathName,
+          numberOfWords, wordOffsetInRegister, flags);
+
+      return boost::shared_ptr<NDRegisterAccessor<UserType>>(d);
+    }
+
+    // Chain up to to the base class using the previously stored function
+    return CALL_BASE_FUNCTION_TEMPLATE(
+        getRegisterAccessor_impl, UserType, registerPathName, numberOfWords, wordOffsetInRegister, flags);
   }
 
 } // namespace ChimeraTK

--- a/src/DummyBackendBase.cc
+++ b/src/DummyBackendBase.cc
@@ -64,8 +64,8 @@ namespace ChimeraTK {
     }
 
     // Chain up to to the base class using the previously stored function
-    return CALL_BASE_FUNCTION_TEMPLATE(NumericAddressedBackend,
-        getRegisterAccessor_impl, UserType, registerPathName, numberOfWords, wordOffsetInRegister, flags);
+    return CALL_BASE_FUNCTION_TEMPLATE(NumericAddressedBackend, getRegisterAccessor_impl, UserType, registerPathName,
+        numberOfWords, wordOffsetInRegister, flags);
   }
 
 } // namespace ChimeraTK

--- a/src/async/MuxedInterruptDistributor.cc
+++ b/src/async/MuxedInterruptDistributor.cc
@@ -105,13 +105,13 @@ namespace ChimeraTK::async {
 
   /********************************************************************************************************************/
 
-  template boost::shared_ptr<AsyncAccessorManager> MuxedInterruptDistributor::getAccessorManager<TriggeredPollDistributor>(
-      std::vector<size_t> const& qualififedSubDomainId);
+  template boost::shared_ptr<AsyncAccessorManager> MuxedInterruptDistributor::getAccessorManager<
+      TriggeredPollDistributor>(std::vector<size_t> const& qualififedSubDomainId);
 
   /********************************************************************************************************************/
 
-  template boost::shared_ptr<AsyncAccessorManager> MuxedInterruptDistributor::getAccessorManager<VariableDistributor<std::nullptr_t>>(
-      std::vector<size_t> const& qualififedSubDomainId);
+  template boost::shared_ptr<AsyncAccessorManager> MuxedInterruptDistributor::getAccessorManager<
+      VariableDistributor<std::nullptr_t>>(std::vector<size_t> const& qualififedSubDomainId);
 
   /********************************************************************************************************************/
   void MuxedInterruptDistributor::activate(VersionNumber version) {

--- a/src/async/MuxedInterruptDistributor.cc
+++ b/src/async/MuxedInterruptDistributor.cc
@@ -104,6 +104,16 @@ namespace ChimeraTK::async {
   }
 
   /********************************************************************************************************************/
+
+  template boost::shared_ptr<AsyncAccessorManager> MuxedInterruptDistributor::getAccessorManager<TriggeredPollDistributor>(
+      std::vector<size_t> const& qualififedSubDomainId);
+
+  /********************************************************************************************************************/
+
+  template boost::shared_ptr<AsyncAccessorManager> MuxedInterruptDistributor::getAccessorManager<VariableDistributor<std::nullptr_t>>(
+      std::vector<size_t> const& qualififedSubDomainId);
+
+  /********************************************************************************************************************/
   void MuxedInterruptDistributor::activate(VersionNumber version) {
     for(auto& subDomainIter : _subDomains) {
       auto subDomain = subDomainIter.second.lock();

--- a/tests/executables_src/testUnifiedTypeChangingDecorator.cpp
+++ b/tests/executables_src/testUnifiedTypeChangingDecorator.cpp
@@ -50,8 +50,12 @@ std::pair<RegisterPath, DecoratorType> getPathAndType(RegisterPath path) {
 class DecoratorBackend : public ExceptionDummy {
  public:
   DecoratorBackend(std::string mapFileName) : ExceptionDummy(mapFileName) {
-    FILL_VIRTUAL_FUNCTION_TEMPLATE_VTABLE(getRegisterAccessor_impl);
+    OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(getRegisterAccessor_impl);
   }
+
+  // Declare that we are going to override getRegisterAccessor_impl
+  DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(getRegisterAccessor_impl,
+      boost::shared_ptr<NDRegisterAccessor<T>>(const RegisterPath&, size_t, size_t, AccessModeFlags));
 
   template<typename UserType>
   boost::shared_ptr<NDRegisterAccessor<UserType>> getRegisterAccessor_impl(
@@ -61,7 +65,8 @@ class DecoratorBackend : public ExceptionDummy {
     auto [path, type] = getPathAndType(registerPathName);
 
     return getTypeChangingDecorator<UserType>(
-        ExceptionDummy::getRegisterAccessor_impl<float>(path, numberOfWords, wordOffsetInRegister, flags), type);
+        CALL_BASE_FUNCTION_TEMPLATE(getRegisterAccessor_impl, float, path, numberOfWords, wordOffsetInRegister, flags),
+        type);
   }
 
   static boost::shared_ptr<DeviceBackend> createInstance(std::string, std::map<std::string, std::string> parameters) {

--- a/tests/executables_src/testUnifiedTypeChangingDecorator.cpp
+++ b/tests/executables_src/testUnifiedTypeChangingDecorator.cpp
@@ -50,11 +50,11 @@ std::pair<RegisterPath, DecoratorType> getPathAndType(RegisterPath path) {
 class DecoratorBackend : public ExceptionDummy {
  public:
   DecoratorBackend(std::string mapFileName) : ExceptionDummy(mapFileName) {
-    OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(getRegisterAccessor_impl);
+    OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(ExceptionDummy, getRegisterAccessor_impl);
   }
 
   // Declare that we are going to override getRegisterAccessor_impl
-  DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(getRegisterAccessor_impl,
+  DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(ExceptionDummy, getRegisterAccessor_impl,
       boost::shared_ptr<NDRegisterAccessor<T>>(const RegisterPath&, size_t, size_t, AccessModeFlags));
 
   template<typename UserType>
@@ -65,7 +65,7 @@ class DecoratorBackend : public ExceptionDummy {
     auto [path, type] = getPathAndType(registerPathName);
 
     return getTypeChangingDecorator<UserType>(
-        CALL_BASE_FUNCTION_TEMPLATE(getRegisterAccessor_impl, float, path, numberOfWords, wordOffsetInRegister, flags),
+        CALL_BASE_FUNCTION_TEMPLATE(ExceptionDummy, getRegisterAccessor_impl, float, path, numberOfWords, wordOffsetInRegister, flags),
         type);
   }
 

--- a/tests/executables_src/testUnifiedTypeChangingDecorator.cpp
+++ b/tests/executables_src/testUnifiedTypeChangingDecorator.cpp
@@ -64,8 +64,8 @@ class DecoratorBackend : public ExceptionDummy {
 
     auto [path, type] = getPathAndType(registerPathName);
 
-    return getTypeChangingDecorator<UserType>(
-        CALL_BASE_FUNCTION_TEMPLATE(ExceptionDummy, getRegisterAccessor_impl, float, path, numberOfWords, wordOffsetInRegister, flags),
+    return getTypeChangingDecorator<UserType>(CALL_BASE_FUNCTION_TEMPLATE(ExceptionDummy, getRegisterAccessor_impl,
+                                                  float, path, numberOfWords, wordOffsetInRegister, flags),
         type);
   }
 

--- a/tests/executables_src/testVirtualFunctionTemplate.cc
+++ b/tests/executables_src/testVirtualFunctionTemplate.cc
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE VirtualFunctionTemplateTest
+#include <boost/test/unit_test.hpp>
+using namespace boost::unit_test_framework;
+
+#include "SupportedUserTypes.h"
+#include "VirtualFunctionTemplate.h"
+
+namespace ChimeraTK {
+class Base {
+ public:
+  Base() { FILL_VIRTUAL_FUNCTION_TEMPLATE_VTABLE(getValue_impl);
+  }
+  template <typename T>
+  std::string getValue(T& base) { return CALL_VIRTUAL_FUNCTION_TEMPLATE(getValue_impl, T, base); }
+
+  DEFINE_VIRTUAL_FUNCTION_TEMPLATE_VTABLE(getValue_impl, std::string(T&));
+
+ private:
+  template<typename T>
+  std::string getValue_impl(T& /*base*/) {
+    return std::string("Base: ") + typeid(T).name();
+  }
+};
+
+class Derived1 : public Base {
+ public:
+  Derived1() { OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(Base, getValue_impl); }
+  DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(Base, getValue_impl, std::string(T&));
+
+ private:
+  template<typename T>
+  std::string getValue_impl(T& base) {
+    if constexpr(std::is_same_v<std::string, T>) {
+      return CALL_BASE_FUNCTION_TEMPLATE(Base, getValue_impl, T, base);
+    }
+    return std::string("Derived1: ") + typeid(T).name();
+  }
+};
+
+class Derived2 : public Derived1 {
+ public:
+  Derived2() { OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(Derived1, getValue_impl); }
+  DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(Derived1, getValue_impl, std::string(T&));
+
+ private:
+  template<typename T>
+  std::string getValue_impl(T& base) {
+    if constexpr(std::is_same_v<float, T>) {
+      return CALL_BASE_FUNCTION_TEMPLATE(Derived1, getValue_impl, T, base);
+    }
+    else if constexpr(std::is_same_v<double, T>) {
+      return CALL_BASE_FUNCTION_TEMPLATE(Base, getValue_impl, T, base);
+    }
+    return std::string("Derived2: ") + typeid(T).name();
+  }
+};
+
+} // namespace ChimeraTK
+
+BOOST_AUTO_TEST_CASE(testBaseClass) {
+  ChimeraTK::Base base;
+  ChimeraTK::userTypeMap typeMap;
+
+  ChimeraTK::for_each(typeMap, [&](auto& pair) {
+    typedef typename std::remove_reference<decltype(pair)>::type::first_type T;
+    T argument;
+    BOOST_TEST(base.getValue<T>(argument) == std::string("Base: ") + typeid(T).name());
+  });
+}
+
+BOOST_AUTO_TEST_CASE(testDerived1Class) {
+  ChimeraTK::Derived1 base;
+  ChimeraTK::userTypeMap typeMap;
+
+  ChimeraTK::for_each(typeMap, [&](auto& pair) {
+    typedef typename std::remove_reference<decltype(pair)>::type::first_type T;
+    T argument;
+    if constexpr(std::is_same_v<T, std::string>) {
+      BOOST_TEST(base.getValue<T>(argument) == std::string("Base: ") + typeid(T).name());
+    } else {
+      BOOST_TEST(base.getValue<T>(argument) == std::string("Derived1: ") + typeid(T).name());
+    }
+  });
+}
+
+BOOST_AUTO_TEST_CASE(testDerived2Class) {
+  ChimeraTK::Derived2 base;
+  ChimeraTK::userTypeMap typeMap;
+
+  ChimeraTK::for_each(typeMap, [&](auto& pair) {
+    typedef typename std::remove_reference<decltype(pair)>::type::first_type T;
+    T argument;
+    if constexpr(std::is_same_v<T, double>) {
+      BOOST_TEST(base.getValue<T>(argument) == std::string("Base: ") + typeid(T).name());
+    } else if constexpr(std::is_same_v<T, float>) {
+      BOOST_TEST(base.getValue<T>(argument) == std::string("Derived1: ") + typeid(T).name());
+    } else {
+      BOOST_TEST(base.getValue<T>(argument) == std::string("Derived2: ") + typeid(T).name());
+    }
+  });
+}

--- a/tests/executables_src/testVirtualFunctionTemplate.cc
+++ b/tests/executables_src/testVirtualFunctionTemplate.cc
@@ -10,54 +10,55 @@ using namespace boost::unit_test_framework;
 #include "VirtualFunctionTemplate.h"
 
 namespace ChimeraTK {
-class Base {
- public:
-  Base() { FILL_VIRTUAL_FUNCTION_TEMPLATE_VTABLE(getValue_impl);
-  }
-  template <typename T>
-  std::string getValue(T& base) { return CALL_VIRTUAL_FUNCTION_TEMPLATE(getValue_impl, T, base); }
-
-  DEFINE_VIRTUAL_FUNCTION_TEMPLATE_VTABLE(getValue_impl, std::string(T&));
-
- private:
-  template<typename T>
-  std::string getValue_impl(T& /*base*/) {
-    return std::string("Base: ") + typeid(T).name();
-  }
-};
-
-class Derived1 : public Base {
- public:
-  Derived1() { OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(Base, getValue_impl); }
-  DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(Base, getValue_impl, std::string(T&));
-
- private:
-  template<typename T>
-  std::string getValue_impl(T& base) {
-    if constexpr(std::is_same_v<std::string, T>) {
-      return CALL_BASE_FUNCTION_TEMPLATE(Base, getValue_impl, T, base);
+  class Base {
+   public:
+    Base() { FILL_VIRTUAL_FUNCTION_TEMPLATE_VTABLE(getValue_impl); }
+    template<typename T>
+    std::string getValue(T& base) {
+      return CALL_VIRTUAL_FUNCTION_TEMPLATE(getValue_impl, T, base);
     }
-    return std::string("Derived1: ") + typeid(T).name();
-  }
-};
 
-class Derived2 : public Derived1 {
- public:
-  Derived2() { OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(Derived1, getValue_impl); }
-  DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(Derived1, getValue_impl, std::string(T&));
+    DEFINE_VIRTUAL_FUNCTION_TEMPLATE_VTABLE(getValue_impl, std::string(T&));
 
- private:
-  template<typename T>
-  std::string getValue_impl(T& base) {
-    if constexpr(std::is_same_v<float, T>) {
-      return CALL_BASE_FUNCTION_TEMPLATE(Derived1, getValue_impl, T, base);
+   private:
+    template<typename T>
+    std::string getValue_impl(T& /*base*/) {
+      return std::string("Base: ") + typeid(T).name();
     }
-    else if constexpr(std::is_same_v<double, T>) {
-      return CALL_BASE_FUNCTION_TEMPLATE(Base, getValue_impl, T, base);
+  };
+
+  class Derived1 : public Base {
+   public:
+    Derived1() { OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(Base, getValue_impl); }
+    DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(Base, getValue_impl, std::string(T&));
+
+   private:
+    template<typename T>
+    std::string getValue_impl(T& base) {
+      if constexpr(std::is_same_v<std::string, T>) {
+        return CALL_BASE_FUNCTION_TEMPLATE(Base, getValue_impl, T, base);
+      }
+      return std::string("Derived1: ") + typeid(T).name();
     }
-    return std::string("Derived2: ") + typeid(T).name();
-  }
-};
+  };
+
+  class Derived2 : public Derived1 {
+   public:
+    Derived2() { OVERRIDE_VIRTUAL_FUNCTION_TEMPLATE(Derived1, getValue_impl); }
+    DEFINE_VIRTUAL_FUNCTION_OVERRIDE_VTABLE(Derived1, getValue_impl, std::string(T&));
+
+   private:
+    template<typename T>
+    std::string getValue_impl(T& base) {
+      if constexpr(std::is_same_v<float, T>) {
+        return CALL_BASE_FUNCTION_TEMPLATE(Derived1, getValue_impl, T, base);
+      }
+      else if constexpr(std::is_same_v<double, T>) {
+        return CALL_BASE_FUNCTION_TEMPLATE(Base, getValue_impl, T, base);
+      }
+      return std::string("Derived2: ") + typeid(T).name();
+    }
+  };
 
 } // namespace ChimeraTK
 
@@ -81,7 +82,8 @@ BOOST_AUTO_TEST_CASE(testDerived1Class) {
     T argument;
     if constexpr(std::is_same_v<T, std::string>) {
       BOOST_TEST(base.getValue<T>(argument) == std::string("Base: ") + typeid(T).name());
-    } else {
+    }
+    else {
       BOOST_TEST(base.getValue<T>(argument) == std::string("Derived1: ") + typeid(T).name());
     }
   });
@@ -96,9 +98,11 @@ BOOST_AUTO_TEST_CASE(testDerived2Class) {
     T argument;
     if constexpr(std::is_same_v<T, double>) {
       BOOST_TEST(base.getValue<T>(argument) == std::string("Base: ") + typeid(T).name());
-    } else if constexpr(std::is_same_v<T, float>) {
+    }
+    else if constexpr(std::is_same_v<T, float>) {
       BOOST_TEST(base.getValue<T>(argument) == std::string("Derived1: ") + typeid(T).name());
-    } else {
+    }
+    else {
       BOOST_TEST(base.getValue<T>(argument) == std::string("Derived2: ") + typeid(T).name());
     }
   });


### PR DESCRIPTION
This fixes a huge chunk of the LTO errors we are seeing on noble.

Frankly it is also unclear why it worked in the first place
