### PR TITLE
feat: implement GenericMuxedInterruptDistributor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ Project(ChimeraTK-DeviceAccess)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/Modules)
 
 set(${PROJECT_NAME}_MAJOR_VERSION 03)
-set(${PROJECT_NAME}_MINOR_VERSION 14)
+set(${PROJECT_NAME}_MINOR_VERSION 15)
 set(${PROJECT_NAME}_PATCH_VERSION 00)
 include(cmake/set_version_numbers.cmake)
 

--- a/backends/DummyBackend/src/DummyBackendRegisterCatalogue.cc
+++ b/backends/DummyBackend/src/DummyBackendRegisterCatalogue.cc
@@ -8,6 +8,7 @@
 namespace ChimeraTK {
 
   constexpr auto DUMMY_WRITEABLE_SUFFIX = "DUMMY_WRITEABLE";
+  constexpr auto DUMMY_READABLE_SUFFIX = "DUMMY_READABLE";
 
   /********************************************************************************************************************/
 
@@ -15,7 +16,7 @@ namespace ChimeraTK {
       const RegisterPath& registerPathName) const {
     auto path = registerPathName;
     path.setAltSeparator(".");
-    if(path.endsWith(DUMMY_WRITEABLE_SUFFIX)) {
+    if(path.endsWith(DUMMY_WRITEABLE_SUFFIX) || path.endsWith(DUMMY_READABLE_SUFFIX)) {
       auto basePath = path;
       basePath--;
       auto info = NumericAddressedRegisterCatalogue::getBackendRegister(basePath);
@@ -36,7 +37,7 @@ namespace ChimeraTK {
   bool DummyBackendRegisterCatalogue::hasRegister(const RegisterPath& registerPathName) const {
     auto path = registerPathName;
     path.setAltSeparator(".");
-    if(path.endsWith(DUMMY_WRITEABLE_SUFFIX)) {
+    if(path.endsWith(DUMMY_WRITEABLE_SUFFIX) || path.endsWith(DUMMY_READABLE_SUFFIX)) {
       auto basePath = path;
       basePath--;
       return NumericAddressedRegisterCatalogue::hasRegister(basePath);

--- a/include/NumericAddressedBackendRegisterAccessor.h
+++ b/include/NumericAddressedBackendRegisterAccessor.h
@@ -158,7 +158,7 @@ namespace ChimeraTK {
       if constexpr(!isRaw || std::is_same<UserType, std::string>::value) {
         if(!_registerInfo.isWriteable()) {
           throw ChimeraTK::logic_error(
-              "NumericAddressedBackend: Writeing to a non-writeable register is not allowed (Register name: " +
+              "NumericAddressedBackend: Writing to a non-writeable register is not allowed (Register name: " +
               _registerInfo.getRegisterName() + ").");
         }
         callForRawType(_registerInfo.getDataDescriptor().rawDataType(), [this](auto t) {
@@ -182,6 +182,11 @@ namespace ChimeraTK {
 
     void doPreRead(TransferType type) override {
       if(!_dev->isOpen()) throw ChimeraTK::logic_error("Device not opened.");
+      if(!_registerInfo.isReadable()) {
+        throw ChimeraTK::logic_error(
+            "NumericAddressedBackend: Reading from a non-readable register is not allowed (Register name: " +
+            _registerInfo.getRegisterName() + ").");
+      }
       _rawAccessor->preRead(type);
     }
 

--- a/include/async/GenericMuxedInterruptDistributor.h
+++ b/include/async/GenericMuxedInterruptDistributor.h
@@ -1,20 +1,102 @@
 // SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
+#include "../NDRegisterAccessor.h"
+#include "../RegisterPath.h"
 #include "MuxedInterruptDistributor.h"
 
 namespace ChimeraTK::async {
 
+  enum GmidOptionCode {
+    ISR = 0, // Interrupt Status Register
+    IER,     // Interrupt Enable Register
+    MER,     // Master Enable Register,
+    MIE,     // Master Interrupt Enable  Functionally equivalent to MER
+    GIE,     // Global Interrupt Enable, Functionally equivalent to MER
+    ICR,     // Interrupt Clear Register
+    IAR,     // Interrupt Acknowledge Register
+    IPR,     // Interrupt Pending Register =ISR & IER, a convenience feature for software.
+    SIE,     // Set Interrupt Enable
+    CIE,     // Clear Interrupt Enable
+    IMaskR,  // Interrupt Mask Register. IMR Acronym Collision. Temporarily not allowed. See
+    IModeR,  // Interrupt Mode Register. IMR Acronym Collision, defined in the standard but not allowed; REMOVE?
+    IVR,     // defined in the standard but not allowed; REMOVE?
+    ILR,     // defined in the standard but not allowed; REMOVE?
+    IVAR,    // defined in the standard but not allowed; REMOVE?
+    IVEAR,   // defined in the standard but not allowed; REMOVE?
+    OPTION_CODE_COUNT, // used for counting how many valid enums there are here & setting list lengths
+    INVALID_OPTION_CODE,
+  };
+
+  /********************************************************************************************************************/
+
   class GenericMuxedInterruptDistributor : public MuxedInterruptDistributor {
    public:
-    explicit GenericMuxedInterruptDistributor(boost::shared_ptr<SubDomain<std::nullptr_t>> parent)
-    : MuxedInterruptDistributor(std::move(parent)) {}
-    ~GenericMuxedInterruptDistributor() override = default;
+    explicit GenericMuxedInterruptDistributor(const boost::shared_ptr<SubDomain<std::nullptr_t>>& parent,
+        const std::string& registerPath, std::bitset<(ulong)GmidOptionCode::OPTION_CODE_COUNT> optionRegisterSettings);
+    ~GenericMuxedInterruptDistributor() override;
 
+    /**
+     * Handle gets called when a trigger comes in. It implements the handshake with the interrupt controller
+     */
     void handle(VersionNumber version) override;
 
-    static std::unique_ptr<GenericMuxedInterruptDistributor> create(
-        std::string const& desrciption, boost::shared_ptr<SubDomain<std::nullptr_t>> parent);
+    void activate(VersionNumber version) override;
+
+    /**
+     *  Create parses the json configuration snippet 'description', and calls the constructor.
+     *  It returns an initalized GenericMuxedInterruptDistributor.
+     *  'descriptor' is a JSON snippet containing configuration data. Elsewhere it's also called descriptionJsonStr
+     */
+    static std::unique_ptr<GenericMuxedInterruptDistributor> create(std::string const& description, // THE JSON SNIPPET
+        const boost::shared_ptr<SubDomain<std::nullptr_t>>& parent);
+
+   protected:
+    bool _ierIsReallyImaskr;
+    bool _haveSieAndCie;
+    bool _hasMer;
+    uint32_t _activeInterrupts{0}; // like a local copy of IER
+
+    boost::shared_ptr<NDRegisterAccessor<uint32_t>> _isr;
+    boost::shared_ptr<NDRegisterAccessor<uint32_t>> _ier; // May point to IER or Imaskr
+    boost::shared_ptr<NDRegisterAccessor<uint32_t>> _icr; // May point to ICR, IAR, or ISR, which act identically
+    boost::shared_ptr<NDRegisterAccessor<uint32_t>> _mer; // May point to MER, MIE, or GIE, all act identically.
+                                                          // We can have at most 1 of {MIE, GIE, MER}
+    boost::shared_ptr<NDRegisterAccessor<uint32_t>> _sie; // We either have both SIE or CIE or neither.
+    boost::shared_ptr<NDRegisterAccessor<uint32_t>> _cie;
+
+    RegisterPath _path; // just a string path, with the added overwritten / operator etc.
+
+    /**
+     * In mask, 1 bits clear the corresponding registers, 0 bits do nothing.
+     * So if bit i of mask is 1, then register i gets cleared
+     * Multiple bits can be 1 at a time.
+     */
+    void clearInterruptsFromMask(uint32_t mask);
+
+    inline void clearOneInterrupt(uint32_t ithInterrupt);
+
+    inline void clearAllInterrupts();
+
+    inline void clearAllEnabledInterrupts();
+
+    /**
+     * Disables each interrupt corresponding to the 1 bits in mask, and updates _activeInterrupts.
+     * Depending on the options, may perform the disable using CIE, IER, or IMaskR.
+     */
+    void disableInterruptsFromMask(uint32_t mask);
+
+    inline void disableOneInterrupt(uint32_t ithInterrupt);
+
+    /**
+     * For each bit in mask that is a 1, the corresponding interrupt gets enabled,
+     * and the internal copy of enabled registers is updated.
+     */
+    void enableInterruptsFromMask(uint32_t mask);
+
+    inline void enableOneInterrupt(uint32_t ithInterrupt);
+
+    void activateSubDomain(SubDomain<std::nullptr_t>& subDomain, VersionNumber const& version) override;
   };
 
 } // namespace ChimeraTK::async

--- a/include/async/MuxedInterruptDistributor.h
+++ b/include/async/MuxedInterruptDistributor.h
@@ -70,7 +70,7 @@ namespace ChimeraTK::async {
     [[nodiscard]] boost::shared_ptr<AsyncAccessorManager> getAccessorManager(
         std::vector<size_t> const& qualififedSubDomainId);
 
-    void activate(VersionNumber version);
+    virtual void activate(VersionNumber version);
     void sendException(const std::exception_ptr& e);
 
     /** The interrupt handling functions implements the handshake with the interrupt controller. It needs to
@@ -89,6 +89,13 @@ namespace ChimeraTK::async {
 
     boost::shared_ptr<SubDomain<std::nullptr_t>> _parent;
     boost::shared_ptr<Domain> _asyncDomain;
+
+    /**
+     *  Function to activate a (new) single SubDomain if the MuxedInterruptDistributor is already active.
+     *  The default implementation just calls activate on the subDomain. Implementations can overload this function to
+     *  perform additional handshakes.
+     */
+    virtual void activateSubDomain(SubDomain<std::nullptr_t>& subDomain, VersionNumber const& version);
   };
 
   /********************************************************************************************************************/

--- a/include/async/SubDomain.h
+++ b/include/async/SubDomain.h
@@ -170,6 +170,11 @@ namespace ChimeraTK::async {
       muxedInterruptDistributor =
           MuxedInterruptDistributorFactory::getInstance().createMuxedInterruptDistributor(this->shared_from_this());
       _muxedInterruptDistributor = muxedInterruptDistributor;
+      if(_domain->unsafeGetIsActive()) {
+        // As for the distributor<nullptr_t> we activate using a new version number, as no version is strictly related
+        // to the "data".
+        muxedInterruptDistributor->activate({});
+      }
     }
 
     return muxedInterruptDistributor->getAccessorManager<DistributorType>(

--- a/src/async/GenericMuxedInterruptDistributor.cc
+++ b/src/async/GenericMuxedInterruptDistributor.cc
@@ -3,27 +3,726 @@
 #include "async/GenericMuxedInterruptDistributor.h"
 
 #include "async/SubDomain.h"
+#include <nlohmann/json.hpp> // https://json.nlohmann.me/features/element_access/
+#include <unordered_map>
+#include <unordered_set>
+
+#include <boost/bimap.hpp>
+
+#include <algorithm>
+#include <sstream>
+#include <vector>
 
 namespace ChimeraTK::async {
+  struct JsonDescriptorKeysV1 {
+    inline static constexpr const int jsonDescriptorVersion = 1;
+    inline static constexpr const char* const VERSION_JSON_KEY = "version";
+    inline static constexpr const char* const OPTIONS_JSON_KEY = "options";
+    inline static constexpr const char* const PATH_JSON_KEY = "path";
+  };
 
-  void GenericMuxedInterruptDistributor::handle(VersionNumber version) {
-    // Stupid testing implementation that always triggers all children
-    for(auto& subDomainIter : _subDomains) {
-      auto subDomain = subDomainIter.second.lock();
-      // The weak pointer might have gone.
-      // FIXME: We need a cleanup function which removes the map entry. Otherwise we might
-      // be stuck with a bad weak pointer wich is tried in each handle() call.
-      if(subDomain) {
-        subDomain->distribute(nullptr, version);
-      }
-    }
+  using JdkV1 = JsonDescriptorKeysV1;
+
+  /********************************************************************************************************************/
+
+  /**
+   * This is an initializer for a boost::bimap so that it can be produced using nice syntax.
+   * Ex: static const auto OptionCodeMap = makeBimap({ {"SIE", SIE}, {"IER", IER}, ... })
+   */
+  boost::bimap<std::string, GmidOptionCode> makeBimap(
+      std::initializer_list<typename boost::bimap<std::string, GmidOptionCode>::value_type> list) {
+    return {list.begin(), list.end()};
   }
 
   /********************************************************************************************************************/
 
-  std::unique_ptr<GenericMuxedInterruptDistributor> GenericMuxedInterruptDistributor::create(
-      [[maybe_unused]] std::string const& desrciption, boost::shared_ptr<SubDomain<std::nullptr_t>> parent) {
-    return std::make_unique<GenericMuxedInterruptDistributor>(std::move(parent));
+  static const auto OptionCodeMap = makeBimap({
+      {"SIE", SIE},
+      {"IER", IER},
+      {"MER", MER},
+      {"MIE", MIE},
+      {"GIE", GIE},
+      {"ISR", ISR},
+      {"ICR", ICR},
+      {"IAR", IAR},
+      {"IPR", IPR},
+      {"CIE", CIE},
+      // Then the unacceptable ones
+      {"IMR", IMaskR},
+      {"IModeR", IModeR}, // REMOVE?
+      {"ILR", ILR},       // REMOVE?
+      {"IVR", IVR},       // REMOVE?
+      {"IVAR", IVAR},     // REMOVE?
+      {"IVEAR", IVEAR},   // REMOVE?
+      {"INVALID_OPTION_CODE", INVALID_OPTION_CODE},
+  });
+
+  /********************************************************************************************************************/
+
+  /**
+   * Return a 32 bit mask with the ithInterrupt bit from the left set to 1 and all others 0
+   */
+  inline uint32_t iToMask(const uint32_t ithInterrupt) {
+    return 0x1U << ithInterrupt;
   }
 
+  /********************************************************************************************************************/
+
+  /**
+   * If the string is not a recognized option code, returns GmidOptionCode::INVALID_OPTION_CODE
+   * It is not the job of this function to do any control logic on these code, just convert the strings
+   * It uses ChimeraTK::async::GmidOptionCodeMap
+   * Example: "ISR" -> GmidOptionCode::ISR
+   * Example: "useless" -> GmidOptionCode::INVALID_OPTION_CODE
+   */
+  GmidOptionCode getOptionRegisterEnum(const std::string& opt) {
+    auto it = OptionCodeMap.left.find(opt);
+    if(it != OptionCodeMap.left.end()) { // If a valid code
+      return it->second;                 // return the corresponding enum.
+    }
+    // invalid code
+    return GmidOptionCode::INVALID_OPTION_CODE;
+  }
+
+  /********************************************************************************************************************/
+
+  /**
+   * Given the Register option code enum, returns the corresponding string.
+   */
+  std::string getOptionRegisterStr(GmidOptionCode optCode) {
+    auto it = OptionCodeMap.right.find(optCode);
+    if(it != OptionCodeMap.right.end()) { // If a valid code
+      return it->second;                  // return the corresponding str.
+    }
+    // invalid code
+    return "INVALID_OPTION_CODE";
+  }
+
+  /********************************************************************************************************************/
+
+  /**
+   * This returns strings explaining the option code acronyms for use in error messages.
+   * Ex: explainOptCode(ISR) ==> "ISR (Interrupt Status Register)"
+   */
+  std::string explainOptCode(GmidOptionCode optCode) {
+    // clang-format off
+      static std::map<GmidOptionCode, std::string> mapOptCode2Message= {
+          {ISR, "Interrupt Status Register"},
+          {IER, "Interrupt Enable Register"},
+          {MER, "Master Enable Register"},
+          {MIE, "Master Interrupt Enable"},
+          {GIE, "Global Interrupt Enable"},
+          {ICR, "Interrupt Clear Register"},
+          {IAR, "Interrupt Acknowledge Register"},
+          {IPR, "Interrupt Pending Register"},
+          {SIE, "Set Interrupt Enable"},
+          {CIE, "Clear Interrupt Enable"},
+          {IMaskR,
+              "Interrupt Mask Register, not to be confused with Interrupt Mode Register"},
+          {IModeR,
+              "Interrupt Mode Register, what AXI INTC v4.1 calls this 'IMR', not to be confused with Interrupt Mask "
+              "Register, which we call 'IMR'"},//REMOVE?
+          {IVR, "Interrupt Vector Register"}, //REMOVE?
+          {ILR, "Interrupt Level Register"},//REMOVE?
+          {IVAR, "Interrupt Vector Address Register"},//REMOVE?
+          {IVEAR, "Interrupt Vector Extended Address Register"},//REMOVE?
+          {INVALID_OPTION_CODE, "No such option code is known"}
+      };
+    // clang-format on
+    return getOptionRegisterStr(optCode) + " (" + mapOptCode2Message[optCode] + ")";
+  }
+
+  /********************************************************************************************************************/
+
+  /**
+   * The default delimiter is ','
+   * TODO move this to some string helper library
+   */
+  std::string strSetToStr(const std::set<std::string>& strSet, char delimiter = ',') {
+    std::string result;
+    if(not strSet.empty()) {
+      for(const auto& str : strSet) {
+        result += str + delimiter;
+      }
+      result.pop_back();
+    }
+    return result;
+  }
+
+  /********************************************************************************************************************/
+
+  /**
+   * Return a string describing the intVec of the form "1,2,3"
+   * The default delimiter is ','
+   * TODO move this to some string helper library
+   */
+  std::string intVecToStr(const std::vector<size_t>& intVec, char delimiter = ',') {
+    std::string result;
+    if(not intVec.empty()) {
+      for(const auto& i : intVec) {
+        result += std::to_string(i) + delimiter;
+      }
+      result.pop_back();
+    }
+    return result;
+  }
+
+  /********************************************************************************************************************/
+
+  /**
+   * Return a string describing the controllerID of the form "[1,2,3]"
+   */
+  std::string controllerIDToStr(const std::vector<size_t>& controllerID) {
+    return "[" + intVecToStr(controllerID, ',') + "]";
+  }
+
+  /********************************************************************************************************************/
+
+  /**
+   * This extracts and validates data from the json snippet 'descriptorJsonStr' that matches the version 1 format
+   * Expect 'descriptionJsonStr' of the form  {"path":"APP.INTCB", "options":{"ICR", "IPR", "MER"...}, "version":1}
+   * controllerID is used for error reporting only.
+   * Returns a pair containing {option flags, registerPath}
+   * options flags as a bitset indexed by the GmidOptionCode enum
+   * registerPath takes the value keyed in the descriptionJson by JsonDescriptorStandardV0::PATH_JSON_KEY ("path")
+   */
+  std::pair<std::bitset<OPTION_CODE_COUNT>, std::string> parseAndValidateJsonDescriptionStrV0(
+      const std::vector<size_t>& controllerID, const std::string& descriptionJsonStr) {
+    /*
+     * throws ChimeraTK::logic_error if there are any problems:
+     *    throws if there are any unexpected keys
+     *    throws if there the json snippet is unparsable
+     *    throws if there the path is not in the snippet
+     *    throws if the json version is != 1
+     *    throws if invalid options given.
+     * This does not validate the logic of the 'options' combination,
+     * this only validates the json snippet.
+     */
+
+    static constexpr const int defaultJsonDescriptorVersion = JdkV1::jsonDescriptorVersion;
+    static const std::vector<std::string> defaultOptionRegisterNames = {"ISR", "IER"};
+    std::string registerPath;
+    std::bitset<OPTION_CODE_COUNT> optionRegisterSettings(0);
+
+    nlohmann::json descriptionJson;
+    try { // **Parse jsonDescriptor and sanitize inputs**
+      descriptionJson = nlohmann::json::parse(descriptionJsonStr);
+    }
+    catch(const nlohmann::json::parse_error& ex) {
+      std::ostringstream oss;
+      oss << "GenericMuxedInterruptDistributor " << controllerIDToStr(controllerID)
+          << " was unable to parse map file json snippet " << descriptionJsonStr;
+      throw ChimeraTK::logic_error(oss.str());
+    }
+
+    // Check that there are no unexpected json keys, throw if there are unexpected keys.
+    for(auto& el : descriptionJson.items()) {
+      if(el.key() != JdkV1::PATH_JSON_KEY and el.key() != JdkV1::OPTIONS_JSON_KEY and
+          el.key() != JdkV1::VERSION_JSON_KEY) {
+        std::ostringstream oss;
+        oss << "Unknown JSON key '" << el.key() << "' provided to map file for GenericMuxedInterruptDistributor "
+            << controllerIDToStr(controllerID);
+        throw ChimeraTK::logic_error(oss.str());
+      }
+    }
+
+    try { // to get registerPath
+      descriptionJson[JdkV1::PATH_JSON_KEY].get_to(registerPath);
+    }
+    catch(const nlohmann::json::exception& e) {
+      std::ostringstream oss;
+      oss << "Map file json register path key '" << JdkV1::PATH_JSON_KEY
+          << "' error for GenericMuxedInterruptDistributor " << controllerIDToStr(controllerID) << ": " << e.what();
+      throw ChimeraTK::logic_error(oss.str());
+    }
+
+    try { // Get Version and check version
+      if(descriptionJson.value("version", defaultJsonDescriptorVersion) != JdkV1::jsonDescriptorVersion) {
+        // version: version of this json descriptor.
+        // if version != 1, or whatever the expected version currently is, throw; if no version, assume 1
+        std::ostringstream oss;
+        oss << "GenericMuxedInterruptDistributor " << controllerIDToStr(controllerID) << " expects a "
+            << JdkV1::VERSION_JSON_KEY << " " << JdkV1::jsonDescriptorVersion << " JSON descriptor, "
+            << JdkV1::VERSION_JSON_KEY << " "
+            << descriptionJson.value(JdkV1::VERSION_JSON_KEY, defaultJsonDescriptorVersion) << " was received.";
+        throw ChimeraTK::logic_error(oss.str());
+      }
+    }
+    catch(const nlohmann::json::exception& e) {
+      std::ostringstream oss;
+      oss << "Map file json " << JdkV1::VERSION_JSON_KEY << " key error for GenericMuxedInterruptDistributor "
+          << controllerIDToStr(controllerID) << ": " << e.what();
+      throw ChimeraTK::logic_error(oss.str());
+    }
+
+    std::vector<std::string> optionRegisterNames;
+    try { // Get Options
+      optionRegisterNames = descriptionJson.value(JdkV1::OPTIONS_JSON_KEY, defaultOptionRegisterNames);
+      // Defaults options are used since options are optional
+    }
+    catch(const nlohmann::json::exception& e) {
+      std::ostringstream oss;
+      oss << "Map file json " << JdkV1::OPTIONS_JSON_KEY << " key error for GenericMuxedInterruptDistributor "
+          << controllerIDToStr(controllerID) << ": " << e.what();
+      throw ChimeraTK::logic_error(oss.str());
+    }
+
+    /*
+     * Note that the case where the json option is provided but empty is covered by
+     * turning on ISR in the constructor and turn on IER with a check below.
+     */
+
+    std::set<std::string> invalidOptionRegisterNamesEncountered;
+    for(const auto& orn : optionRegisterNames) {
+      if(GmidOptionCode ornCode = getOptionRegisterEnum(orn); ornCode != INVALID_OPTION_CODE) {
+        optionRegisterSettings.set(ornCode);
+      }
+      else {
+        invalidOptionRegisterNamesEncountered.insert(orn);
+      }
+    }
+    if(!invalidOptionRegisterNamesEncountered.empty()) { // Throw if there are unknown options
+      std::ostringstream oss;
+      oss << "Invalid register options " << strSetToStr(invalidOptionRegisterNamesEncountered)
+          << " supplied in the map file json descriptor (key = " << JdkV1::OPTIONS_JSON_KEY
+          << ") for GenericMuxedInterruptDistributor " << controllerIDToStr(controllerID);
+      throw ChimeraTK::logic_error(oss.str());
+    }
+
+    return std::make_pair(optionRegisterSettings, registerPath);
+  } // parseAndValidateJsonDescriptionStrV0
+
+  /********************************************************************************************************************/
+
+  /**
+   * Ensures permissible combinations of option registers
+   * by throwing ChimeraTK::logic_error if there are any problems.
+   */
+  void steriliseOptionRegisterSettings(
+      std::bitset<OPTION_CODE_COUNT> const& optionRegisterSettings, std::vector<size_t> const& controllerID) {
+    /*
+     * This enforces the following rules:
+     *   throw if ISR not set
+     *   throw if neither IER nor IMaskR are set.
+     *   throw if IMaskR and IER are both set.
+     *   throw if SIE xor CIE is set
+     *   throw if IMaskR is set as well as SIE or CIE
+     *   throw if ICR and IAR are both set.
+     *   throw if more than 0 of MIE, GIE, MER are set.
+     *   Temporary: throw if IMaskR is set
+     */
+
+    /*----------------------------------------------------------------------------------------------------------------*/
+    // Throw if only SIE or CIE is there, but not both
+    if(optionRegisterSettings.test(SIE) != optionRegisterSettings.test(CIE)) {
+      std::ostringstream oss;
+      oss << "Invalid register " << JdkV1::OPTIONS_JSON_KEY
+          << " combination specified in map file json descriptor for GenericMuxedInterruptDistributor "
+          << controllerIDToStr(controllerID) << ": Only " << explainOptCode(SIE) << " or " << explainOptCode(CIE)
+          << " is set, but not both.";
+      throw ChimeraTK::logic_error(oss.str());
+    }
+    /*----------------------------------------------------------------------------------------------------------------*/
+    // Throw if IMaskR is set as well as SIE or CIE
+    if(optionRegisterSettings.test(IMaskR)) {
+      if(optionRegisterSettings.test(SIE)) {
+        std::ostringstream oss;
+        oss << "Invalid register " << JdkV1::OPTIONS_JSON_KEY
+            << " combination specified in map file json descriptor for GenericMuxedInterruptDistributor "
+            << controllerIDToStr(controllerID) << ": " << explainOptCode(SIE) << " and " << explainOptCode(IMaskR)
+            << " cannot not both be set.";
+        throw ChimeraTK::logic_error(oss.str());
+      }
+      if(optionRegisterSettings.test(CIE)) {
+        std::ostringstream oss;
+        oss << "Invalid register " << JdkV1::OPTIONS_JSON_KEY
+            << " combination specified in map file json descriptor for GenericMuxedInterruptDistributor "
+            << controllerIDToStr(controllerID) << ": " << explainOptCode(CIE) << " and " << explainOptCode(IMaskR)
+            << " cannot not both be set.";
+        throw ChimeraTK::logic_error(oss.str());
+      }
+    }
+    /*----------------------------------------------------------------------------------------------------------------*/
+    // Throw if both ICR and IAR are there
+    if(optionRegisterSettings.test(ICR) and optionRegisterSettings.test(IAR)) {
+      std::ostringstream oss;
+      oss << "Invalid register " << JdkV1::OPTIONS_JSON_KEY
+          << " combination specified in map file json descriptor for GenericMuxedInterruptDistributor "
+          << controllerIDToStr(controllerID) << ": " << explainOptCode(ICR) << " and " << explainOptCode(IAR)
+          << " cannot not both be set.";
+      throw ChimeraTK::logic_error(oss.str());
+    }
+    /*----------------------------------------------------------------------------------------------------------------*/
+    // Throw if both IMaskR and IER are there
+    if(optionRegisterSettings.test(IMaskR) and optionRegisterSettings.test(IER)) {
+      std::ostringstream oss;
+      oss << "Invalid register " << JdkV1::OPTIONS_JSON_KEY
+          << " combination specified in map file json descriptor for GenericMuxedInterruptDistributor "
+          << controllerIDToStr(controllerID) << ": Only " << explainOptCode(IMaskR) << " and " << explainOptCode(IER)
+          << " cannot not both be set.";
+      throw ChimeraTK::logic_error(oss.str());
+    }
+    /*----------------------------------------------------------------------------------------------------------------*/
+    // Throw if neither IER nor IMaskR is set. This should be impossible.
+    if(not(optionRegisterSettings.test(IMaskR) or optionRegisterSettings.test(IER))) {
+      std::ostringstream oss;
+      oss << "Invalid register " << JdkV1::OPTIONS_JSON_KEY << " for GenericMuxedInterruptDistributor "
+          << controllerIDToStr(controllerID) << ": Neither " << explainOptCode(IMaskR) << " nor " << explainOptCode(IER)
+          << " are set, one of the two is required.";
+      throw ChimeraTK::logic_error(oss.str());
+    }
+
+    /*----------------------------------------------------------------------------------------------------------------*/
+    // Throw if more than one entry of [MIE, GIE, MER] is there (test all combinations)
+    int nMieGieMer = static_cast<int>(optionRegisterSettings.test(MIE)) +
+        static_cast<int>(optionRegisterSettings.test(GIE)) + static_cast<int>(optionRegisterSettings.test(MER));
+    if(nMieGieMer > 1) {
+      std::ostringstream oss;
+      oss << "Invalid register " << JdkV1::OPTIONS_JSON_KEY
+          << " combination specified in map file json descriptor for GenericMuxedInterruptDistributor "
+          << controllerIDToStr(controllerID) << ": Only one out of " << explainOptCode(MIE) << ", "
+          << explainOptCode(GIE) << ", and " << explainOptCode(MER) << " can be set; " << std::to_string(nMieGieMer)
+          << " are set.";
+      throw ChimeraTK::logic_error(oss.str());
+    }
+
+    /*----------------------------------------------------------------------------------------------------------------*/
+    // Throw if unsupported options options received
+    if(optionRegisterSettings.test(IModeR)) { // REMOVE?
+      std::ostringstream oss;
+      oss << "Unsupported register " << JdkV1::OPTIONS_JSON_KEY
+          << " specified in map file json descriptor for GenericMuxedInterruptDistributor "
+          << controllerIDToStr(controllerID) << ": While " << explainOptCode(IModeR)
+          << " is a defined options in the AXI IntC v4.1 register space, it is not currently an allowed options in"
+             " the GenericMuxedInterruptDistributor";
+      throw ChimeraTK::logic_error(oss.str());
+    }
+
+    if(optionRegisterSettings.test(IVEAR) or optionRegisterSettings.test(IVAR) or optionRegisterSettings.test(IVR) or
+        optionRegisterSettings.test(ILR) or optionRegisterSettings.test(IModeR)) { // REMOVE?
+      std::ostringstream oss;
+      oss << "Unsupported register " << JdkV1::OPTIONS_JSON_KEY
+          << " specified in map file json descriptor for GenericMuxedInterruptDistributor "
+          << controllerIDToStr(controllerID) << ": While " << explainOptCode(ILR) << ", " << explainOptCode(IVR) << ", "
+          << explainOptCode(IVAR) << ", and " << explainOptCode(IVEAR)
+          << "are defined options in the AXI IntC v4.1 register space, they are not currently allowed options in the "
+             "GenericMuxedInterruptDistributor";
+      throw ChimeraTK::logic_error(oss.str());
+    }
+
+    if(optionRegisterSettings.test(IMaskR)) { // Temporary, this throw should be removed in a later version. TODO
+      std::ostringstream oss;
+      oss << "Unsupported register " << JdkV1::OPTIONS_JSON_KEY
+          << " specified in map file json descriptor for GenericMuxedInterruptDistributor "
+          << controllerIDToStr(controllerID) << ": " << explainOptCode(IMaskR)
+          << " is not currently an allowed options in the GenericMuxedInterruptDistributor, but should be supported "
+             "in a later version. ";
+      throw ChimeraTK::logic_error(oss.str());
+    }
+    /*----------------------------------------------------------------------------------------------------------------*/
+    // throw if ISR is not set. This should be impossible.
+    if(not optionRegisterSettings.test(ISR)) {
+      std::ostringstream oss;
+      oss << explainOptCode(ISR) << " is required but is not enabled for GenericMuxedInterruptDistributor "
+          << controllerIDToStr(controllerID);
+      throw ChimeraTK::logic_error(oss.str());
+    }
+  } // steriliseOptionRegisterSettings
+
+  /********************************************************************************************************************/
+  /********************************************************************************************************************/
+  /********************************************************************************************************************/
+
+  GenericMuxedInterruptDistributor::GenericMuxedInterruptDistributor(
+      const boost::shared_ptr<SubDomain<std::nullptr_t>>& parent, const std::string& registerPath,
+      std::bitset<GmidOptionCode::OPTION_CODE_COUNT> optionRegisterSettings)
+  : MuxedInterruptDistributor(parent), _path(registerPath.c_str()) {
+    // Set required registers
+    optionRegisterSettings.set(ISR);              // Ensure that the required option ISR is always set.
+    if(not optionRegisterSettings.test(IMaskR)) { // Ensure IMaskR or IER is on
+      optionRegisterSettings.set(IER);
+    }
+    // Note that we currently don't allowing IMaskR, but use of it gets caught later.
+
+    // Here we could explicitly note that we're ignoring IPR with optionRegisterSettings.reset(IPR)
+
+    /*----------------------------------------------------------------------------------------------------------------*/
+    steriliseOptionRegisterSettings(optionRegisterSettings, parent->getId());
+
+    /*----------------------------------------------------------------------------------------------------------------*/
+    _isr = _backend->getRegisterAccessor<uint32_t>(_path / getOptionRegisterStr(ISR), 1, 0, {});
+
+    _ierIsReallyImaskr = optionRegisterSettings.test(IMaskR);
+    _ier = _backend->getRegisterAccessor<uint32_t>(
+        _path / getOptionRegisterStr(_ierIsReallyImaskr ? IMaskR : IER), 1, 0, {});
+
+    // Set the clear/acknowledge register {ICR, IAR, ISR}
+    if(optionRegisterSettings.test(ICR)) { // Use ICR as the clear register
+      _icr = _backend->getRegisterAccessor<uint32_t>(_path / getOptionRegisterStr(ICR), 1, 0, {});
+    }
+    else if(optionRegisterSettings.test(IAR)) { // Use IAR as the clear register
+      _icr = _backend->getRegisterAccessor<uint32_t>(_path / getOptionRegisterStr(IAR), 1, 0, {});
+    }
+    else { // Use ISR to clear interrupts using its write 1 to clear feature
+      _icr = _backend->getRegisterAccessor<uint32_t>(_path / getOptionRegisterStr(ISR), 1, 0, {});
+    }
+
+    _hasMer = optionRegisterSettings.test(MER) or optionRegisterSettings.test(MIE) or optionRegisterSettings.test(GIE);
+    if(_hasMer) {
+      GmidOptionCode _optionMerMieGie =
+          optionRegisterSettings.test(MIE) ? MIE : (optionRegisterSettings.test(GIE) ? GIE : MER);
+      _mer = _backend->getRegisterAccessor<uint32_t>(_path / getOptionRegisterStr(_optionMerMieGie), 1, 0, {});
+    }
+
+    // steriliseOptionRegisterSettings ensures that either SIE and CIE are both enabled or neither are
+    _haveSieAndCie = optionRegisterSettings.test(SIE);
+    if(_haveSieAndCie) {
+      _sie = _backend->getRegisterAccessor<uint32_t>(_path / getOptionRegisterStr(SIE), 1, 0, {});
+      _cie = _backend->getRegisterAccessor<uint32_t>(_path / getOptionRegisterStr(CIE), 1, 0, {});
+    }
+
+    /*----------------------------------------------------------------------------------------------------------------*/
+    // Check register readability/writeability
+    // We have to check the catalogue, because this is the expected behaviour, so we
+    // are allowed to throw a logic error here.
+    // If the accessor actually behaves differently, it will cause a runtime error when used (which is expected
+    // behaviour and OK.) For map-file based backends the behaviour of catalogue and accessor should always be
+    // consistent.
+    auto catalogue = _backend->getRegisterCatalogue();
+
+    auto checkRedable = [catalogue](auto& accessor) {
+      auto description = catalogue.getRegister(accessor->getName());
+      if(!description.isReadable()) {
+        throw ChimeraTK::logic_error(
+            "GenericMuxedInterruptDistributor: Handshake register not readable: " + accessor->getName());
+      }
+    };
+    auto checkWriteable = [catalogue](auto& accessor) {
+      auto description = catalogue.getRegister(accessor->getName());
+      if(!description.isWriteable()) {
+        throw ChimeraTK::logic_error(
+            "GenericMuxedInterruptDistributor: Handshake register not writeable: " + accessor->getName());
+      }
+    };
+
+    checkRedable(_isr);   // we only read from it
+    checkWriteable(_ier); // we only write to ier as we are the only user (otherwise we need sie and cie)
+    checkWriteable(_icr); // usually write only
+    if(_mer) {
+      // we only write, never read
+      checkWriteable(_mer);
+    }
+    if(_sie) {
+      checkWriteable(_sie); // usually write only
+    }
+    if(_cie) {
+      checkWriteable(_cie); // usually write only
+    }
+  } // constructor
+
+  /********************************************************************************************************************/
+  GenericMuxedInterruptDistributor::~GenericMuxedInterruptDistributor() {
+    if(_backend->isFunctional()) {
+      try {
+        disableInterruptsFromMask(_activeInterrupts);
+      }
+      catch(ChimeraTK::logic_error& e) {
+        // This try/catch is just to silence the linter. ChimeraTK logic errors can always be avoided by checking the
+        // according pre-condition. We did so by checking isFunctional, so there should be no exception here.
+        std::cerr << "Logic error in ~GenericMuxedInterruptDistributor: " << e.what() << " TERMINATING!" << std::endl;
+        std::terminate();
+      }
+    }
+
+  } // destructor
+
+  /********************************************************************************************************************/
+  void GenericMuxedInterruptDistributor::clearInterruptsFromMask(uint32_t mask) {
+    try {
+      _icr->accessData(0) = mask;
+      _icr->write();
+    }
+    catch(ChimeraTK::runtime_error&) {
+    }
+  }
+
+  /********************************************************************************************************************/
+  inline void GenericMuxedInterruptDistributor::clearOneInterrupt(uint32_t ithInterrupt) {
+    clearInterruptsFromMask(iToMask(ithInterrupt));
+  }
+
+  /********************************************************************************************************************/
+  inline void GenericMuxedInterruptDistributor::clearAllInterrupts() {
+    clearInterruptsFromMask(0xFFFFFFFF);
+  }
+
+  /********************************************************************************************************************/
+  inline void GenericMuxedInterruptDistributor::clearAllEnabledInterrupts() {
+    clearInterruptsFromMask(_activeInterrupts);
+  }
+
+  /********************************************************************************************************************/
+  void GenericMuxedInterruptDistributor::disableInterruptsFromMask(uint32_t mask) {
+    _activeInterrupts &= ~mask;
+    try {
+      if(_ierIsReallyImaskr) {
+        // IMaskR is used, so SIE and CIE are not defined.
+        _ier->accessData(0) = ~_activeInterrupts;
+        _ier->write();
+      }
+      else {
+        if(_haveSieAndCie) {
+          _cie->accessData(0) = mask;
+          _cie->write();
+        }
+        else {
+          _ier->accessData(0) = _activeInterrupts;
+          _ier->write();
+        }
+      }
+      clearInterruptsFromMask(mask);
+    }
+    catch(ChimeraTK::runtime_error&) {
+    }
+  }
+
+  /********************************************************************************************************************/
+  inline void GenericMuxedInterruptDistributor::disableOneInterrupt(uint32_t ithInterrupt) {
+    disableInterruptsFromMask(iToMask(ithInterrupt));
+  }
+
+  /********************************************************************************************************************/
+  void GenericMuxedInterruptDistributor::enableInterruptsFromMask(uint32_t mask) {
+    /*
+     * - When creating an accessor to "!0:N" (or a nested interrupt "!0:N:M") //MIR = IMR = IMaskR.
+     *   - if SIE and CIE are there, it writes ``1<<N`` to SIE and _clears_ with ``1<<N``
+     *   - if IMR is there, it writes ~(``1<<N``) to IMR and _clears_ with ``1<<N``
+     *   - if neither (SIE and CIE) nor MIR are present, or only IER is there, it writes ``1<<N`` to IER
+     * and _clears_ with ``1<<N``
+     * - When creating accessor "!0:L" while still holding "!0:N"
+     *   - if SIE and CIE are there, it writes `1<<L` to SIE and to CIE
+     *   - if IMR is there, it writes ~( (``1<<N``) | (`1<<L`) ) to MIR and _clears_ with `1<<L`
+     *   - if neither (SIE and CIE) nor IMR are present, or only IER is there, it writes ( ``1<<N``)|(`1<<L`)
+     * to IER and _clears_ with `1<<L`
+     */
+    _activeInterrupts |= mask;
+    try {
+      if(_ierIsReallyImaskr) { // Set IMaskR in the form of IER
+        _ier->accessData(0) = ~_activeInterrupts;
+        _ier->write();
+        // When IMaskR is used, SIE and CIE cannot be defined.
+      }
+      else {
+        if(_haveSieAndCie) { // Set SIE
+          _sie->accessData(0) = _activeInterrupts;
+          _sie->write();
+        }
+        else { // Set IER, which actually is IER and not IMaskR
+          _ier->accessData(0) = _activeInterrupts;
+          _ier->write();
+        }
+      }
+    }
+    catch(ChimeraTK::runtime_error&) {
+    }
+  } // enableInterruptFromMask
+
+  /********************************************************************************************************************/
+  inline void GenericMuxedInterruptDistributor::enableOneInterrupt(uint32_t ithInterrupt) {
+    enableInterruptsFromMask(iToMask(ithInterrupt));
+  }
+
+  /********************************************************************************************************************/
+  void GenericMuxedInterruptDistributor::handle(VersionNumber version) {
+    try {
+      _isr->read();
+      uint32_t ipr = _activeInterrupts & _isr->accessData(0);
+
+      for(auto const& [i, subDomainWeakPtr] : _subDomains) {
+        // i is the bit index of the subDomain
+        if(ipr & iToMask(i)) {
+          if(auto subDomain = subDomainWeakPtr.lock(); subDomain) {
+            //  The weak pointer might have gone.
+            //  TODO FIXME: We need a cleanup function which removes the map entry.
+            //  Otherwise we might be stuck with a bad weak pointer which is tried in each handle() call.
+
+            subDomain->distribute(nullptr, version);
+
+            // Requirement: nested interrupt handlers must clear their active interrupt flag first,
+            // then the parent interrupt flags are cleared.
+            clearOneInterrupt(i);
+          }
+        }
+      } // for
+    }
+    catch(ChimeraTK::runtime_error&) {
+      // There's nothing to do. The transferElement part of _activeInterrupts has already called the backend's setException
+    }
+  } // handle
+
+  /********************************************************************************************************************/
+  std::unique_ptr<GenericMuxedInterruptDistributor> GenericMuxedInterruptDistributor::create(
+      [[maybe_unused]] std::string const& description, const boost::shared_ptr<SubDomain<std::nullptr_t>>& parent) {
+    /*
+     *  This is a factory function. It parses the json, and calls the constructor.
+     *  It returns an initalized GenericMuxedInterruptDistributor.
+     *  'description' is a JSON snippet containing configuration data
+     */
+
+    auto parseResult = parseAndValidateJsonDescriptionStrV0(parent->getId(), description);
+    std::bitset<OPTION_CODE_COUNT> optionRegisterSettings = parseResult.first;
+    std::string registerPath = parseResult.second;
+
+    return std::make_unique<GenericMuxedInterruptDistributor>(parent, registerPath, optionRegisterSettings);
+  } // create
+
+  /********************************************************************************************************************/
+  void GenericMuxedInterruptDistributor::activate(VersionNumber version) {
+    if(_hasMer) { // Set MER: turn on the Master Enable and HIE (hardware interrupt enable) bits
+      try {
+        _mer->accessData(0) = 0x00000003;
+        _mer->write();
+      }
+      catch(ChimeraTK::runtime_error&) {
+      }
+    }
+
+    // Disable any interrupts for which there is no valid subDomain.
+    uint32_t activeInterrupts = 0;
+    for(auto const& [i, subDomainWeakPtr] : _subDomains) {
+      try {
+        if(subDomainWeakPtr.lock()) {
+          activeInterrupts |= iToMask(i);
+        }
+      }
+      catch(ChimeraTK::runtime_error&) {
+      }
+    } // for
+    enableInterruptsFromMask(activeInterrupts);
+
+    clearAllEnabledInterrupts();
+
+    // Activate all existing sub-domains. We have to implement a loop here because the parent activate is calling
+    // activateSubDomain() internally, which is not necessary because we already wrote to the hardware to do the
+    // handshake.
+    for(auto& subDomainIter : _subDomains) {
+      auto subDomain = subDomainIter.second.lock();
+      if(subDomain) {
+        subDomain->activate(nullptr, version);
+      }
+    }
+  } // activate
+
+  /********************************************************************************************************************/
+  void GenericMuxedInterruptDistributor::activateSubDomain(
+      SubDomain<std::nullptr_t>& subDomain, VersionNumber const& version) {
+    auto index = subDomain.getId().back();
+
+    enableInterruptsFromMask(iToMask(index));
+    clearInterruptsFromMask(iToMask(index));
+
+    subDomain.activate(nullptr, version);
+  }
+
+  /********************************************************************************************************************/
 } // namespace ChimeraTK::async

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,7 @@ MACRO( COPY_MAPPING_FILES )
     bitRangeReadPlugin.xlmap
     decoratorTest.map
     testMappedImage.dmap testMappedImage.map
+    irq_test.mapp
     DESTINATION ${PROJECT_BINARY_DIR}/tests)
   # The valid dmap file has an absolute path which has to be configured by cmake
   # They cannot just be copied.

--- a/tests/executables_src/testGenericMuxedInterruptDistributor.cpp
+++ b/tests/executables_src/testGenericMuxedInterruptDistributor.cpp
@@ -1,0 +1,706 @@
+// SPDX-FileCopyrightText: Deutsches Elektronen-Synchrotron DESY, MSK, ChimeraTK Project <chimeratk-support@desy.de>
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#define BOOST_TEST_DYN_LINK
+#define BOOST_TEST_MODULE GenericMuxedInterruptDistributorTest
+#include "Device.h"
+#include "DummyBackend.h"
+#include "DummyRegisterAccessor.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include <chrono>
+#include <thread>
+
+using namespace ChimeraTK;
+using namespace boost::unit_test_framework;
+
+bool readWithTimeout(VoidRegisterAccessor& acc, size_t msTimeout = 3000) {
+  auto startTime = std::chrono::steady_clock::now();
+  auto currentTime = startTime;
+  while(currentTime < startTime + std::chrono::milliseconds(msTimeout)) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    if(acc.readNonBlocking()) {
+      return true;
+    }
+    currentTime = std::chrono::steady_clock::now();
+  }
+  return false;
+}
+
+BOOST_AUTO_TEST_SUITE(INTCHandlerTestSuite)
+
+static constexpr std::string_view testCdd{"(WriteMonitoring:xdma/slot5?map=irq_test.mapp)"};
+
+/********************************************************************************************************************/
+
+// We need a special backend because the firmware has several "clear on 1", which internally modify
+// individual bits in a word. We have to monitor the writes and log this state. Only looking at the last write is not sufficient.
+class WriteMonitoringBackend : public DummyBackend {
+ public:
+  WriteMonitoringBackend(const std::string& mapFileName) : DummyBackend(mapFileName) {
+    acknowledged["ISR"] = 0;
+    acknowledged["IAR"] = 0;
+    acknowledged["ICR"] = 0;
+
+    setWriteCallbackFunction(AddressRange(0, 0x00800008, 4),
+        [&] { acknowledged["ISR"] |= static_cast<uint32_t>(getRawAccessor("TEST0", "ISR")); });
+    setWriteCallbackFunction(AddressRange(0, 0x0090000C, 4),
+        [&] { acknowledged["IAR"] |= static_cast<uint32_t>(getRawAccessor("TEST1", "IAR")); });
+    setWriteCallbackFunction(AddressRange(0, 0x00A0000C, 4),
+        [&] { acknowledged["ICR"] |= static_cast<uint32_t>(getRawAccessor("TEST2", "ICR")); });
+    setWriteCallbackFunction(AddressRange(0, 0x00D00008, 4),
+        [&] { acknowledged["ISR"] |= static_cast<uint32_t>(getRawAccessor("TEST5", "ISR")); });
+    setWriteCallbackFunction(AddressRange(0, 0x00D0000C, 4), // comment for formatting
+        [&] { sie |= static_cast<uint32_t>(getRawAccessor("TEST5", "SIE")); });
+  }
+
+  static boost::shared_ptr<DeviceBackend> createInstance(
+      [[maybe_unused]] std::string address, std::map<std::string, std::string> parameters) {
+    if(parameters["map"].empty()) {
+      throw ChimeraTK::logic_error("No map file name given.");
+    }
+    return boost::shared_ptr<DeviceBackend>(new WriteMonitoringBackend(parameters["map"]));
+  }
+
+  std::map<std::string, uint32_t> acknowledged;
+  uint32_t sie{0};
+};
+
+class BackendRegisterer {
+ public:
+  BackendRegisterer() {
+    ChimeraTK::BackendFactory::getInstance().registerBackendType(
+        "WriteMonitoring", &WriteMonitoringBackend::createInstance);
+  }
+};
+
+static BackendRegisterer b;
+
+/********************************************************************************************************************/
+
+struct TestFixture {
+  Device device{std::string{testCdd}};
+  VoidRegisterAccessor accInterrupt;
+  VoidRegisterAccessor dummyInterrupt;
+  ScalarRegisterAccessor<uint32_t> isr;
+  uint32_t _interrupt;
+  boost::shared_ptr<WriteMonitoringBackend> dummyBackend;
+
+  TestFixture(uint32_t interrupt, bool activateAsyncFirst) : _interrupt(interrupt) {
+    dummyBackend = boost::dynamic_pointer_cast<WriteMonitoringBackend>(device.getBackend());
+    assert(dummyBackend);
+
+    if(activateAsyncFirst) {
+      device.open();
+      device.activateAsyncRead();
+    }
+
+    accInterrupt.replace(device.getVoidRegisterAccessor(
+        "!" + std::to_string(interrupt) + ":4", {ChimeraTK::AccessMode::wait_for_new_data}));
+    dummyInterrupt.replace(device.getVoidRegisterAccessor("DUMMY_INTERRUPT_" + std::to_string(interrupt)));
+    isr.replace(
+        device.getScalarRegisterAccessor<uint32_t>("TEST" + std::to_string(interrupt) + "/ISR/DUMMY_WRITEABLE"));
+
+    if(activateAsyncFirst) {
+      // only if asyncRead is active we will get an initial value. Pop it here for convenience.
+      BOOST_TEST(readWithTimeout(accInterrupt));
+    }
+  }
+
+  virtual ~TestFixture() { device.close(); }
+};
+
+/********************************************************************************************************************/
+
+/**
+ * Test that a logic error is thrown as soon as you try to get an accessor with invalid map file entries.
+ * Print the exception message for manual checking. Don't automate checking the string content. It is not
+ * part of the API and subject to refactoring.
+ */
+struct ThrowTestFixture {
+  Device device{std::string{testCdd}};
+  VoidRegisterAccessor accInterrupt;
+
+  ThrowTestFixture(uint32_t interrupt) {
+    std::string testRegister("!" + std::to_string(interrupt) + ":4");
+    try {
+      accInterrupt.replace(device.getVoidRegisterAccessor(testRegister, {ChimeraTK::AccessMode::wait_for_new_data}));
+      BOOST_CHECK_MESSAGE(false, "Creating register \"" + testRegister + "\" did not throw as expected!");
+    }
+    catch(ChimeraTK::logic_error& e) {
+      std::cout << "Caught expected exception for " << boost::unit_test::framework::current_test_case().p_name
+                << ". Print for manual check of message: " << e.what() << std::endl;
+      BOOST_CHECK(true); // just to have a hook for the last successful test
+    }
+  }
+};
+
+/********************************************************************************************************************/
+
+struct Inactive0 : public TestFixture {
+  Inactive0() : TestFixture(0, false) {}
+};
+BOOST_FIXTURE_TEST_CASE(inactiveIER, Inactive0) {
+  device.open();
+
+  auto ier = device.getScalarRegisterAccessor<int>("TEST0/IER");
+  ier.read();
+  BOOST_TEST(0x0 == ier);
+  BOOST_TEST(dummyBackend->acknowledged["ISR"] == 0);
+
+  device.activateAsyncRead();
+
+  ier.read();
+  BOOST_TEST(0x10 == ier);
+  BOOST_TEST(dummyBackend->acknowledged["ISR"] == 0x10);
+  dummyBackend->acknowledged["ISR"] = 0;
+
+  auto accInterrupt2 = device.getVoidRegisterAccessor("!0:5", {ChimeraTK::AccessMode::wait_for_new_data});
+  ier.read();
+  BOOST_TEST(ier == 0x30);
+  BOOST_TEST(dummyBackend->acknowledged["ISR"] == 0x20); // we must NOT acknowledge 0x10 again!
+
+  accInterrupt.replace(VoidRegisterAccessor{});
+
+  // FIXME: This is the expected result if the SubDomain destructor would notify the MuxedInterruptDistributor.
+  // This is not implemented yet.
+#if false
+  ier.read();
+  BOOST_TEST(ier == 0x20); // only the second iterator remains
+#endif
+
+  // at this point the Domain and with it the MuxedInterruptDistributor goe out of scope, and the distributor's
+  // destructor is kicking in.
+  accInterrupt2.replace(VoidRegisterAccessor{});
+  ier.read();
+  BOOST_TEST(ier == 0x0);
+}
+
+struct Active0 : public TestFixture {
+  Active0() : TestFixture(0, true) {}
+};
+BOOST_FIXTURE_TEST_CASE(activateIER, Active0) {
+  auto ier = device.getScalarRegisterAccessor<int>("TEST0/IER");
+  ier.read();
+  BOOST_TEST(0x10 == ier);
+  BOOST_TEST(dummyBackend->acknowledged["ISR"] == 0x10);
+  // no need to repeat all following tests in inactiveIER here.
+}
+
+/*********************************************************************************************************************/
+BOOST_AUTO_TEST_CASE(activateOnActiveDomain) {
+  // Test that the activation is called correctly for all members if the upper layers in the distribution tree are
+  // already active Tree:
+  //
+  // Domain 3 - SubDomain [3] -- VariableDistributor<void> [3]
+  //                          \_ MuxedInterruptDistibutor  [3] --- SubDomain [3, 0] -- VariableDistributor<void> [3, 0]
+  //                                                           \                    \_ MuxedInterruptDistibutor  [3, 0]
+  //                                                            \_ SubDomain [3, 1] -- VariableDistributor<void> [3, 1]
+  //                                                                                \_ MuxedInterruptDistibutor  [3, 1]
+  ChimeraTK::Device device;
+  device.open(std::string{testCdd});
+  device.activateAsyncRead();
+
+  // Create the domain and check that it is active
+  auto accessor3 = device.getVoidRegisterAccessor("!3", {AccessMode::wait_for_new_data});
+  readWithTimeout(accessor3); // initial value
+  auto dummyInterruptTrigger =
+      device.getVoidRegisterAccessor("DUMMY_INTERRUPT_3"); // for triggering the dummy interrupt
+  dummyInterruptTrigger.write();
+  readWithTimeout(accessor3); // initial value
+
+  // Test 1: get an accessor for a sub SubDomain of MuxedInterruptDistibutor [3], which is in the already
+  // active SubDomain [3].
+  auto acc3_0 = device.getVoidRegisterAccessor("!3:0", {AccessMode::wait_for_new_data});
+  readWithTimeout(acc3_0);
+
+  // Test that the MuxedInterruptDistibutor [3] has been activated
+  // MER might be write-only
+  BOOST_TEST(
+      device.read<int32_t>("TEST3/MER/DUMMY_READABLE") == 0x3); // MER always has two bits which both have to be set
+
+  // Test that the handshake for sub-domain [3, 0] has been activated
+  BOOST_TEST(device.read<uint32_t>("TEST3/IER") == (1U << 0));
+
+  // Test 2: The the SubDomain behind the MuxedInterruptDistributor [3] itself is activated (not only the handshake) if
+  // the distributor is already active. We use SubDomain [3, 1] for this and test the SubDomain activation indirectly by
+  // the activation of the MuxedInterruptDistibutor  [3, 1]
+  auto acc3_1 = device.getVoidRegisterAccessor("!3:1:3", {AccessMode::wait_for_new_data});
+  readWithTimeout(acc3_1);
+
+  BOOST_TEST(device.read<int32_t>("TEST3/SUB1/MER") == 0x3);
+  BOOST_TEST(device.read<uint32_t>("TEST3/SUB1/IER") == (1U << 3));
+}
+
+struct AcknowledgeTest : public TestFixture {
+  AcknowledgeTest(uint32_t interrupt, std::string ackReg) : TestFixture(interrupt, true), ackRegister(ackReg) {}
+
+  VoidRegisterAccessor accInterrupt2;
+  std::string ackRegister;
+
+  void run() {
+    // acknowledge has been written when activating
+    BOOST_TEST(dummyBackend->acknowledged[ackRegister] == 0x10);
+
+    // prepare the status before sending the interrupt
+    // set one more bit to be sensitive to the handshake (need to see changes)
+    isr.setAndWrite(0x11);
+
+    dummyBackend->acknowledged[ackRegister] = 0;
+
+    dummyInterrupt.write();
+    // wait until interrupt handler is done
+    BOOST_TEST(readWithTimeout(accInterrupt));
+
+    BOOST_TEST(dummyBackend->acknowledged[ackRegister] == 0x10);
+
+    dummyBackend->acknowledged[ackRegister] = 0;
+    accInterrupt2.replace(device.getVoidRegisterAccessor(
+        "!" + std::to_string(_interrupt) + ":5", {ChimeraTK::AccessMode::wait_for_new_data}));
+    BOOST_TEST(dummyBackend->acknowledged[ackRegister] == 0x20);
+    readWithTimeout(accInterrupt2); // pop the initial value
+
+    // Signal the first accessor
+
+    isr.setAndWrite(0x11);
+
+    dummyBackend->acknowledged[ackRegister] = 0;
+    dummyInterrupt.write();
+    BOOST_TEST(readWithTimeout(accInterrupt));
+    BOOST_CHECK(!accInterrupt2.readNonBlocking());
+
+    BOOST_TEST(dummyBackend->acknowledged[ackRegister] == 0x10);
+    if(ackRegister != "ISR") {
+      BOOST_TEST(isr.readAndGet() == 0x11);
+    }
+
+    // Signal the second accessor
+    isr.setAndWrite(0x21);
+
+    dummyBackend->acknowledged[ackRegister] = 0;
+    dummyInterrupt.write();
+    BOOST_TEST(readWithTimeout(accInterrupt2));
+    BOOST_CHECK(!accInterrupt.readNonBlocking());
+
+    BOOST_TEST(dummyBackend->acknowledged[ackRegister] == 0x20);
+    if(ackRegister != "ISR") {
+      BOOST_TEST(isr.readAndGet() == 0x21);
+    }
+
+    // Signal both
+    isr.setAndWrite(0x31);
+
+    dummyBackend->acknowledged[ackRegister] = 0;
+    dummyInterrupt.write();
+    BOOST_TEST(readWithTimeout(accInterrupt));
+    BOOST_TEST(readWithTimeout(accInterrupt2));
+
+    BOOST_TEST(dummyBackend->acknowledged[ackRegister] == 0x30);
+    if(ackRegister != "ISR") {
+      BOOST_TEST(isr.readAndGet() == 0x31);
+    }
+  }
+};
+
+/**********************************************************************************************************************/
+
+// ISR is used as acknowledge register
+struct IsrTestFixture : public AcknowledgeTest {
+  IsrTestFixture() : AcknowledgeTest(0, "ISR") {}
+};
+BOOST_FIXTURE_TEST_CASE(testISR, IsrTestFixture) {
+  run();
+}
+
+/**********************************************************************************************************************/
+/*if IAR is present: INTC writes 1<<n the according bit mask to IAR and not to ISR*/
+struct IarTestFixture : public AcknowledgeTest {
+  IarTestFixture() : AcknowledgeTest(1, "IAR") {}
+};
+BOOST_FIXTURE_TEST_CASE(testIAR, IarTestFixture) {
+  run();
+}
+
+/**********************************************************************************************************************/
+/* if ICR is present: INTC writes 1<<n the according bit mask to ICR and not to ISR */
+
+struct IcrTestFixture : public AcknowledgeTest {
+  IcrTestFixture() : AcknowledgeTest(2, "ICR") {}
+};
+BOOST_FIXTURE_TEST_CASE(testICR, IcrTestFixture) {
+  run();
+}
+
+struct MasterEnableTest : public TestFixture {
+  MasterEnableTest(uint32_t interrupt, std::string meRegister, bool enableFirst)
+  : TestFixture(interrupt, enableFirst), isEnabled(enableFirst) {
+    masterEnable.replace(device.getScalarRegisterAccessor<uint32_t>(
+        RegisterPath("TEST" + std::to_string(interrupt)) / meRegister / "DUMMY_READABLE"));
+  }
+
+  ScalarRegisterAccessor<uint32_t> masterEnable;
+  bool isEnabled;
+
+  void run() {
+    if(!isEnabled) {
+      device.open();
+
+      // MER should not be set
+      BOOST_TEST(masterEnable.readAndGet() == 0x0);
+
+      device.activateAsyncRead();
+    }
+
+    // MER should be set now
+    BOOST_TEST(masterEnable.readAndGet() == 0x3); // last two bits active
+  }
+};
+/********************************************************************************************************************/
+
+struct MerInactiveTestFixture : public MasterEnableTest {
+  MerInactiveTestFixture() : MasterEnableTest(3, "MER", false) {}
+};
+BOOST_FIXTURE_TEST_CASE(testMerInactive, MerInactiveTestFixture) {
+  run();
+}
+struct MerActiveTestFixture : public MasterEnableTest {
+  MerActiveTestFixture() : MasterEnableTest(3, "MER", true) {}
+};
+BOOST_FIXTURE_TEST_CASE(testMerActive, MerActiveTestFixture) {
+  run();
+}
+
+/********************************************************************************************************************/
+BOOST_AUTO_TEST_CASE(testIMR) { // TEST4
+  ChimeraTK::Device device;
+
+  device.open("(dummy:xdma/slot5?map=irq_test.mapp)");
+  BOOST_TEST(device.isOpened() == true);
+
+  auto imr = device.getScalarRegisterAccessor<uint32_t>("TEST4.IMR");
+  imr.setAndWrite(0x7F); // 7 bits in this register (see map file)
+
+  // IMR is not implemented yet. This is giving an exception at the moment.
+  try {
+    auto accInterrput = device.getScalarRegisterAccessor<int>("!4:4", 0, {ChimeraTK::AccessMode::wait_for_new_data});
+    BOOST_CHECK_MESSAGE(false, "IMR not detected as invalid option.");
+  }
+  catch(ChimeraTK::logic_error& e) {
+    std::cout << "Caught expected exeption. Print for manual check of message: " << e.what() << std::endl;
+    // We skip the rest of the test for now, but leave the code below.
+    return;
+  }
+
+  device.activateAsyncRead();
+
+  BOOST_TEST(imr.readAndGet() == 0x6F);
+
+  device.close();
+}
+
+/********************************************************************************************************************/
+
+struct Inactive5 : public TestFixture {
+  Inactive5() : TestFixture(5, false) {}
+};
+BOOST_FIXTURE_TEST_CASE(testSieCie, Inactive5) {
+  auto sie = device.getScalarRegisterAccessor<int>("TEST5/SIE/DUMMY_READABLE");
+  auto cie = device.getScalarRegisterAccessor<int>("TEST5/CIE/DUMMY_READABLE");
+
+  device.open();
+
+  // pre-condition: both registers are 0
+  BOOST_TEST(sie.readAndGet() == 0x0);
+  BOOST_TEST(cie.readAndGet() == 0x0);
+  BOOST_TEST(dummyBackend->acknowledged["ISR"] == 0x0);
+  BOOST_TEST(isr.readAndGet() == 0x0);
+
+  // activate
+  device.activateAsyncRead();
+
+  // only SIE has been written
+  BOOST_TEST(sie.readAndGet() == 0x10);
+  BOOST_TEST(isr.readAndGet() == 0x10);
+  BOOST_TEST(dummyBackend->acknowledged["ISR"] == 0x10);
+  BOOST_TEST(cie.readAndGet() == 0x0);
+
+  // remove the accessor. CIE should be written
+  accInterrupt.replace(VoidRegisterAccessor{});
+
+  BOOST_TEST(cie.readAndGet() == 0x10);
+}
+
+BOOST_FIXTURE_TEST_CASE(testSieCieMulti1, Inactive5) {
+  // Mixed activation: the second accessor is created AFTER activateAsyncRead
+  auto sie = device.getScalarRegisterAccessor<int>("TEST5/SIE/DUMMY_READABLE");
+  auto cie = device.getScalarRegisterAccessor<int>("TEST5/CIE/DUMMY_READABLE");
+
+  device.open();
+  device.activateAsyncRead();
+  BOOST_TEST(sie.readAndGet() == 0x10); // just to be safe, we already know this from the previous test
+  BOOST_TEST(dummyBackend->acknowledged["ISR"] == 0x10);
+  dummyBackend->acknowledged["ISR"] = 0x0;
+
+  auto accInterrupt2 = device.getVoidRegisterAccessor("!5:5", {ChimeraTK::AccessMode::wait_for_new_data});
+  sie.read();
+  BOOST_CHECK_MESSAGE((sie == 0x20) || // the implementation can either only set the new bit
+          (sie == 0x30),               // or send the whole mask again
+      "SIE is " + std::to_string(sie) + ", but should be 0x20 or 0x30");
+  BOOST_TEST(dummyBackend->acknowledged["ISR"] == 0x20); // we must NOT acknowledge 0x10 again!
+
+  accInterrupt.replace(VoidRegisterAccessor{});
+
+  // FIXME: This is the expected result if the SubDomain destructor would notify the MuxedInterruptDistributor.
+  // This is not implemented yet.
+#if false
+  BOOST_TEST(cie.readAndGet() == 0x10);
+#endif
+
+  // at this point the Domain and with it the MuxedInterruptDistributor goe out of scope, and the distributor's
+  // destructor is kicking in.
+  accInterrupt2.replace(VoidRegisterAccessor{});
+
+  // FIXME: Finally wanted behaviour: There is only one accessor left
+#if false
+  BOOST_TEST(cie.readAndGet() == 0x20);
+#endif
+  // Actual behaviour: Both flags are written at the same time.
+  BOOST_TEST(cie.readAndGet() == 0x30);
+}
+
+BOOST_FIXTURE_TEST_CASE(testSieCieMulti2, Inactive5) {
+  // Create both accessors first, then call activateAsyncRead()
+  // No need to check the clear section again. It's the same as above.
+  auto accInterrupt2 = device.getVoidRegisterAccessor("!5:5", {ChimeraTK::AccessMode::wait_for_new_data});
+
+  BOOST_TEST(dummyBackend->sie == 0x0);
+  BOOST_TEST(dummyBackend->acknowledged["ISR"] == 0x0);
+
+  device.open();
+  device.activateAsyncRead();
+
+  BOOST_TEST(dummyBackend->sie == 0x30); // both bits set, no matter whether at the same time or individually
+  BOOST_TEST(dummyBackend->acknowledged["ISR"] == 0x30);
+}
+
+/**********************************************************************************************************************/
+
+struct GieInactiveTestFixture : public MasterEnableTest {
+  GieInactiveTestFixture() : MasterEnableTest(6, "GIE", false) {}
+};
+BOOST_FIXTURE_TEST_CASE(testGieInactive, GieInactiveTestFixture) {
+  run();
+}
+struct GieActiveTestFixture : public MasterEnableTest {
+  GieActiveTestFixture() : MasterEnableTest(6, "GIE", true) {}
+};
+BOOST_FIXTURE_TEST_CASE(testGieActive, GieActiveTestFixture) {
+  run();
+}
+
+/********************************************************************************************************************/
+
+struct MieInactiveTestFixture : public MasterEnableTest {
+  MieInactiveTestFixture() : MasterEnableTest(7, "MIE", false) {}
+};
+BOOST_FIXTURE_TEST_CASE(testMieInactive, MieInactiveTestFixture) {
+  run();
+}
+struct MieActiveTestFixture : public MasterEnableTest {
+  MieActiveTestFixture() : MasterEnableTest(7, "MIE", true) {}
+};
+BOOST_FIXTURE_TEST_CASE(testMieActive, MieActiveTestFixture) {
+  run();
+}
+
+/********************************************************************************************************************/
+/* ERROR Scenarios */
+/**********************************************************************************************************************/
+
+struct UnknownOptionTestFixture : public ThrowTestFixture {
+  UnknownOptionTestFixture() : ThrowTestFixture(10) {}
+};
+BOOST_FIXTURE_TEST_CASE(testUnknownOption, UnknownOptionTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct InvalidJson1TestFixture : public ThrowTestFixture {
+  InvalidJson1TestFixture() : ThrowTestFixture(11) {}
+};
+BOOST_FIXTURE_TEST_CASE(testJsonErrorInGeneralStructure, InvalidJson1TestFixture) {}
+
+/********************************************************************************************************************/
+
+struct InvalidJson2TestFixture : public ThrowTestFixture {
+  InvalidJson2TestFixture() : ThrowTestFixture(12) {}
+};
+BOOST_FIXTURE_TEST_CASE(testJsonErrorInIntcSprecific, InvalidJson2TestFixture) {}
+
+/********************************************************************************************************************/
+
+struct OnlySieTestFixture : public ThrowTestFixture {
+  OnlySieTestFixture() : ThrowTestFixture(13) {}
+};
+BOOST_FIXTURE_TEST_CASE(testOnlySie, OnlySieTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct OnlyCieTestFixture : public ThrowTestFixture {
+  OnlyCieTestFixture() : ThrowTestFixture(14) {}
+};
+BOOST_FIXTURE_TEST_CASE(testOnlyCie, OnlyCieTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct IarAndIcrTestFixture : public ThrowTestFixture {
+  IarAndIcrTestFixture() : ThrowTestFixture(15) {}
+};
+BOOST_FIXTURE_TEST_CASE(testIarAndIcr, IarAndIcrTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct NoIsrTestFixture : public ThrowTestFixture {
+  NoIsrTestFixture() : ThrowTestFixture(16) {}
+};
+BOOST_FIXTURE_TEST_CASE(testNoIsr, NoIsrTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct NoIerTestFixture : public ThrowTestFixture {
+  NoIerTestFixture() : ThrowTestFixture(17) {}
+};
+BOOST_FIXTURE_TEST_CASE(testNoIer, NoIerTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct NoPathTestFixture : public ThrowTestFixture {
+  NoPathTestFixture() : ThrowTestFixture(18) {}
+};
+BOOST_FIXTURE_TEST_CASE(testNoPath, NoPathTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct NonexistendPathTestFixture : public ThrowTestFixture {
+  NonexistendPathTestFixture() : ThrowTestFixture(118) {}
+};
+BOOST_FIXTURE_TEST_CASE(testNonexistendPath, NonexistendPathTestFixture) {}
+
+/********************************************************************************************************************/
+
+// Adapt this when more versions are added
+struct UnknownVersionTestFixture : public ThrowTestFixture {
+  UnknownVersionTestFixture() : ThrowTestFixture(19) {}
+};
+BOOST_FIXTURE_TEST_CASE(testUnknownVersion, UnknownVersionTestFixture) {}
+
+/********************************************************************************************************************/
+
+// Adapt this when more versions are added
+struct UnknownMainKeyTestFixture : public ThrowTestFixture {
+  UnknownMainKeyTestFixture() : ThrowTestFixture(20) {}
+};
+BOOST_FIXTURE_TEST_CASE(testUnknownMainKey, UnknownMainKeyTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct MieAndGieTestFixture : public ThrowTestFixture {
+  MieAndGieTestFixture() : ThrowTestFixture(21) {}
+};
+BOOST_FIXTURE_TEST_CASE(testMieAndGie, MieAndGieTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct MieAndMerTestFixture : public ThrowTestFixture {
+  MieAndMerTestFixture() : ThrowTestFixture(22) {}
+};
+BOOST_FIXTURE_TEST_CASE(testMieAndMer, MieAndMerTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct GieAndMerTestFixture : public ThrowTestFixture {
+  GieAndMerTestFixture() : ThrowTestFixture(23) {}
+};
+BOOST_FIXTURE_TEST_CASE(testGieAndMer, GieAndMerTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct MieGieAndMerTestFixture : public ThrowTestFixture {
+  MieGieAndMerTestFixture() : ThrowTestFixture(24) {}
+};
+BOOST_FIXTURE_TEST_CASE(testMieGieAndMer, MieGieAndMerTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct IsrReadableTestFixture : public ThrowTestFixture {
+  IsrReadableTestFixture() : ThrowTestFixture(25) {}
+};
+BOOST_FIXTURE_TEST_CASE(testIsrReadable, IsrReadableTestFixture) {}
+
+/********************************************************************************************************************/
+
+// ISR must be writeable if there is no ICR/IAR
+struct IsrWritableTestFixture : public ThrowTestFixture {
+  IsrWritableTestFixture() : ThrowTestFixture(26) {}
+};
+BOOST_FIXTURE_TEST_CASE(testIsrWriteable, IsrWritableTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct IerWritableTestFixture : public ThrowTestFixture {
+  IerWritableTestFixture() : ThrowTestFixture(27) {}
+};
+BOOST_FIXTURE_TEST_CASE(testIerWriteable, IerWritableTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct IcrWritableTestFixture : public ThrowTestFixture {
+  IcrWritableTestFixture() : ThrowTestFixture(28) {}
+};
+BOOST_FIXTURE_TEST_CASE(testIcrWriteable, IcrWritableTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct IarWritableTestFixture : public ThrowTestFixture {
+  IarWritableTestFixture() : ThrowTestFixture(29) {}
+};
+BOOST_FIXTURE_TEST_CASE(testIarWriteable, IarWritableTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct MieWritableTestFixture : public ThrowTestFixture {
+  MieWritableTestFixture() : ThrowTestFixture(30) {}
+};
+BOOST_FIXTURE_TEST_CASE(testMieWriteable, MieWritableTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct GieWritableTestFixture : public ThrowTestFixture {
+  GieWritableTestFixture() : ThrowTestFixture(31) {}
+};
+BOOST_FIXTURE_TEST_CASE(testGieWriteable, GieWritableTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct MerWritableTestFixture : public ThrowTestFixture {
+  MerWritableTestFixture() : ThrowTestFixture(32) {}
+};
+BOOST_FIXTURE_TEST_CASE(testMerWriteable, MerWritableTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct SieWritableTestFixture : public ThrowTestFixture {
+  SieWritableTestFixture() : ThrowTestFixture(33) {}
+};
+BOOST_FIXTURE_TEST_CASE(testSieWriteable, SieWritableTestFixture) {}
+
+/********************************************************************************************************************/
+
+struct CieWritableTestFixture : public ThrowTestFixture {
+  CieWritableTestFixture() : ThrowTestFixture(34) {}
+};
+BOOST_FIXTURE_TEST_CASE(testCieWriteable, CieWritableTestFixture) {}
+
+/********************************************************************************************************************/
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/irq_test.mapp
+++ b/tests/irq_test.mapp
@@ -1,0 +1,275 @@
+@![0]   {"INTC" : {"path": "TEST0", "version":1} }
+
+@![1] {"INTC" : {"path": "TEST1", "options": ["IAR"], "version":1} }
+@![2] {"INTC" : {"path": "TEST2", "options": ["ICR"], "version":1} }
+
+@![3] {"INTC" : {"path": "TEST3", "options": ["MER"],  "version":1} }
+@![3,0] {"INTC" : {"path": "TEST3.SUB0"}  "options": []}
+@![3,1] {"INTC" : {"path": "TEST3.SUB1", "options": ["MER"]} }
+
+@![4] {"INTC" : {"path": "TEST4", "options": ["IMR"], "version":1} }
+@![5] {"INTC" : {"path": "TEST5", "options": ["SIE", "CIE"], "version":1} }
+@![6] {"INTC" : {"path": "TEST6", "options": ["GIE","IPR"], "version":1} }
+@![7] {"INTC" : {"path": "TEST7", "options": ["MIE"], "version":1} }
+
+@![10] {"INTC" : {"path": "TEST10", "options": ["UNKNOWN"] }}
+
+# invalid json1 (first parsing step, general structure)
+@![11] {"INTC" : {"path": "TEST11"}
+
+# invalid json2 (second parsing step, controller specific description)
+@![12] {"INTC" : {"path": "TEST12",  "options": {"IER"} }}
+
+# Only SIE, no CIE (must come together)
+@![13] {"INTC" : {"path": "TEST13",  "options": ["SIE"]} }
+
+# Only CIE, no SIE (must come together)
+@![14] {"INTC" : {"path": "TEST14",  "options": ["CIE"]} }
+
+# both ICR and IAR are there
+@![15] {"INTC" : {"path": "TEST15",  "options": ["ICR", "IAR"]} }
+
+# No ISR in the register set
+@![16] {"INTC" : {"path": "TEST16"} }
+
+# No IER in the register set
+@![17] {"INTC" : {"path": "TEST17"} }
+
+# No path
+@![18] {"INTC" : {"options": ["IER"]} }
+
+# Path does not exist
+@![118] {"INTC" : {"path": "TEST118"} }
+
+# Unknown version
+@![19] {"INTC" : {"path": "TEST19", "version":9999999} }
+
+# Unknown primary key 
+@![20] {"INTC" : {"path": "TEST20", "answerToEverything": 42} }
+
+# both MIE and GIE are there
+@![21] {"INTC" : {"path": "TEST21",  "options": ["MIE", "GIE"]} }
+
+# both MIE and MER are there
+@![22] {"INTC" : {"path": "TEST21",  "options": ["MIE", "MER"]} }
+
+# both GIE and MER are there
+@![23] {"INTC" : {"path": "TEST21",  "options": ["GIE", "MER"]} }
+
+# all  MIE, GIE and MER are there
+@![24] {"INTC" : {"path": "TEST21",  "options": ["MIE", "GIE", "MER"]} }
+
+# ISR must be readable
+@![25] {"INTC" : {"path": "TEST25"} }
+
+# ISR must be writeable if there is no ICR/IAR
+@![26] {"INTC" : {"path": "TEST26"} }
+
+# IER must be writeable
+@![27] {"INTC" : {"path": "TEST27"} }
+
+# ICR must be writeable
+@![28] {"INTC" : {"path": "TEST28", "options": ["ICR"]} }
+
+# IAR must be writeable
+@![29] {"INTC" : {"path": "TEST29", "options": ["IAR"]} }
+
+# MIE must be writeable
+@![30] {"INTC" : {"path": "TEST30", "options": ["MIE"]} }
+
+# GIE must be writeable
+@![31] {"INTC" : {"path": "TEST31", "options": ["GIE"]} }
+
+# MER must be writeable
+@![32] {"INTC" : {"path": "TEST32", "options": ["MER"]} }
+
+# SIE must be writeable
+@![33] {"INTC" : {"path": "TEST33", "options": ["SIE", "CIE"]} }
+
+# CIE must be writeable
+@![34] {"INTC" : {"path": "TEST34", "options": ["SIE", "CIE"]} }
+
+TEST0.IER                                                     1  0x0080000C            4    0    7    0    0   RW
+TEST0.ISR                                                     1  0x00800008            4    0    7    0    0   RW
+TEST0.DAQ_READY                                               0  0x00000000            0    0    0    0    0   INTERRUPT0:4
+TEST0.SECOND_INTERRUPT                                        0  0x00000000            0    0    0    0    0   INTERRUPT0:5
+
+TEST1.IER                                                     1  0x00900000            4    0    7    0    0   RW
+TEST1.IAR                                                     1  0x0090000C            4    0    7    0    0   WO
+TEST1.ISR                                                     1  0x00900008            4    0    7    0    0   RO
+TEST1.DAQ_READY                                               0  0x00000000            0    0    0    0    0   INTERRUPT1:4
+TEST1.SECOND_INTERRUPT                                        0  0x00000000            0    0    0    0    0   INTERRUPT1:5
+
+TEST2.IER                                                     1  0x00A00000            4    0    7    0    0   WO
+TEST2.ICR                                                     1  0x00A0000C            4    0    7    0    0   WO
+TEST2.ISR                                                     1  0x00A00008            4    0    7    0    0   RO
+TEST2.DAQ_READY                                               0  0x00000000            0    0    0    0    0   INTERRUPT2:4
+TEST2.SECOND_INTERRUPT                                        0  0x00000000            0    0    0    0    0   INTERRUPT2:5
+
+TEST3.IER                                                     1  0x00B00000            4    0    7    0    0   RW
+TEST3.ISR                                                     1  0x00B00008            4    0    7    0    0   RW
+TEST3.MER                                                     1  0x00B0001C            4    0    2    0    0   WO
+TEST3.DAQ_READY                                               0  0x00000000            0    0    0    0    0   INTERRUPT3:4
+TEST3.SUB0.IER                                                1  0x00B0010C            4    0   32    0    0   RW
+TEST3.SUB0.ISR                                                1  0x00B00108            4    0   32    0    0   RW
+TEST3.SUB0.READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT3:0:2
+TEST3.SUB1.IER                                                1  0x00B00200            4    0   16    0    0   RW
+TEST3.SUB1.ISR                                                1  0x00B00208            4    0   16    0    0   RW
+TEST3.SUB1.MER                                                1  0x00B0020C            4    0   16    0    0   RW
+TEST3.SUB1.READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT3:1:3
+
+TEST4.IMR                                                     1  0x00C0000C            4    0    7    0    0   RW
+TEST4.ISR                                                     1  0x00C00008            4    0    7    0    0   RW
+TEST4.DAQ_READY                                               0  0x00000000            0    0    0    0    0   INTERRUPT4:4
+
+TEST5.SIE                                                     1  0x00D0000C            4    0    7    0    0   WO
+TEST5.CIE                                                     1  0x00D00004            4    0    7    0    0   WO
+TEST5.IER                                                     1  0x00D00000            4    0    7    0    0   RW
+TEST5.ISR                                                     1  0x00D00008            4    0    7    0    0   RW
+TEST5.DAQ_READY                                               0  0x00000000            0    0    0    0    0   INTERRUPT5:4
+TEST5.SECOND_INTERRUPT                                        0  0x00000000            0    0    0    0    0   INTERRUPT5:5
+
+TEST6.GIE                                                     1  0x00E0000C            4    0    7    0    0   WO
+TEST6.IER                                                     1  0x00E00000            4    0    7    0    0   RW
+TEST6.IPR                                                     1  0x00E00004            4    0    7    0    0   RW
+TEST6.ISR                                                     1  0x00E00008            4    0    7    0    0   RW
+TEST6.DAQ_READY                                               0  0x00000000            0    0    0    0    0   INTERRUPT6:4
+
+
+TEST7.MIE                                                     1  0x00F0000C            4    0    7    0    0   WO
+TEST7.IER                                                     1  0x00F00004            4    0    7    0    0   RW
+TEST7.ISR                                                     1  0x00F00008            4    0    7    0    0   RW
+TEST7.DAQ_READY                                               0  0x00000000            0    0    0    0    0   INTERRUPT7:4
+
+TEST10.UNKNOWN                                                1  0x0000100C            4    0    7    0    0   RW
+TEST10.IER                                                    1  0x00001004            4    0    7    0    0   RW
+TEST10.ISR                                                    1  0x00001008            4    0    7    0    0   RW
+TEST10.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT10:4
+
+TEST11.IER                                                    1  0x00002004            4    0    7    0    0   RW
+TEST11.ISR                                                    1  0x00002008            4    0    7    0    0   RW
+TEST11.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT11:4
+
+TEST12.IER                                                    1  0x00003004            4    0    7    0    0   RW
+TEST12.ISR                                                    1  0x00003008            4    0    7    0    0   RW
+TEST12.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT12:4
+
+TEST13.SIE                                                    1  0x0000400C            4    0    7    0    0   RW
+TEST13.IER                                                    1  0x00004004            4    0    7    0    0   RW
+TEST13.ISR                                                    1  0x00004008            4    0    7    0    0   RW
+TEST13.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT13:4
+
+TEST14.CIE                                                    1  0x0000500C            4    0    7    0    0   RW
+TEST14.IER                                                    1  0x00005004            4    0    7    0    0   RW
+TEST14.ISR                                                    1  0x00005008            4    0    7    0    0   RW
+TEST14.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT14:4
+
+TEST15.IAR                                                    1  0x0000600C            4    0    7    0    0   RW
+TEST15.ICR                                                    1  0x00006004            4    0    7    0    0   RW
+TEST15.ISR                                                    1  0x00006008            4    0    7    0    0   RW
+TEST15.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT15:4
+
+TEST16.IER                                                    1  0x00007004            4    0    7    0    0   RW
+TEST16.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT16:4
+
+TEST17.ISR                                                    1  0x00008008            4    0    7    0    0   RW
+TEST17.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT17:4
+
+TEST18.IER                                                    1  0x00009004            4    0    7    0    0   RW
+TEST18.ISR                                                    1  0x00009008            4    0    7    0    0   RW
+TEST18.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT18:4
+
+TEST118.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT118:4
+
+TEST19.IER                                                    1  0x0000A004            4    0    7    0    0   RW
+TEST19.ISR                                                    1  0x0000A008            4    0    7    0    0   RW
+TEST19.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT19:4
+
+TEST20.IER                                                    1  0x0000B004            4    0    7    0    0   RW
+TEST20.ISR                                                    1  0x0000B008            4    0    7    0    0   RW
+TEST20.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT20:4
+
+TEST21.MIE                                                    1  0x0000C000            4    0    7    0    0   RW
+TEST21.GIE                                                    1  0x0000C00C            4    0    7    0    0   RW
+TEST21.IER                                                    1  0x0000C004            4    0    7    0    0   RW
+TEST21.ISR                                                    1  0x0000C008            4    0    7    0    0   RW
+TEST21.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT21:4
+
+TEST22.MIE                                                    1  0x0000D000            4    0    7    0    0   RW
+TEST22.MER                                                    1  0x0000D00C            4    0    7    0    0   RW
+TEST22.IER                                                    1  0x0000D004            4    0    7    0    0   RW
+TEST22.ISR                                                    1  0x0000D008            4    0    7    0    0   RW
+TEST22.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT22:4
+
+TEST23.GIE                                                    1  0x0000E000            4    0    7    0    0   RW
+TEST23.MER                                                    1  0x0000E00C            4    0    7    0    0   RW
+TEST23.IER                                                    1  0x0000E004            4    0    7    0    0   RW
+TEST23.ISR                                                    1  0x0000E008            4    0    7    0    0   RW
+TEST23.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT23:4
+
+TEST24.MIE                                                    1  0x0000F010            4    0    7    0    0   RW
+TEST24.GIE                                                    1  0x0000F000            4    0    7    0    0   RW
+TEST24.MER                                                    1  0x0000F00C            4    0    7    0    0   RW
+TEST24.IER                                                    1  0x0000F004            4    0    7    0    0   RW
+TEST24.ISR                                                    1  0x0000F008            4    0    7    0    0   RW
+TEST24.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT24:4
+
+# isr must be readable
+TEST25.IER                                                    1  0x00010004            4    0    7    0    0   RW
+TEST25.ISR                                                    1  0x00010008            4    0    7    0    0   WO
+TEST25.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT25:4
+
+# isr must be writeable if there is no ICR/IAR
+TEST26.IER                                                    1  0x00011004            4    0    7    0    0   RW
+TEST26.ISR                                                    1  0x00011008            4    0    7    0    0   RO
+TEST26.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT26:4
+
+# ier must be writeable
+TEST27.IER                                                    1  0x00012004            4    0    7    0    0   RO
+TEST27.ISR                                                    1  0x00012008            4    0    7    0    0   RW
+TEST27.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT27:4
+
+# icr must be writeable
+TEST28.ICR                                                    1  0x0001300C            4    0    7    0    0   RO
+TEST28.IER                                                    1  0x00013004            4    0    7    0    0   RW
+TEST28.ISR                                                    1  0x00013008            4    0    7    0    0   RW
+TEST28.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT28:4
+
+# iar must be writeable
+TEST29.IAR                                                    1  0x0001400C            4    0    7    0    0   RO
+TEST29.IER                                                    1  0x00014004            4    0    7    0    0   RW
+TEST29.ISR                                                    1  0x00014008            4    0    7    0    0   RW
+TEST29.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT29:4
+
+# mie must be writeable
+TEST30.MIE                                                    1  0x00015010            4    0    7    0    0   RO
+TEST30.IER                                                    1  0x00015004            4    0    7    0    0   RW
+TEST30.ISR                                                    1  0x00015008            4    0    7    0    0   RW
+TEST30.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT30:4
+
+# gie must be writeable
+TEST31.GIE                                                    1  0x00015000            4    0    7    0    0   RO
+TEST31.IER                                                    1  0x00015004            4    0    7    0    0   RW
+TEST31.ISR                                                    1  0x00015008            4    0    7    0    0   RW
+TEST31.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT31:4
+
+# mer must be writeable
+TEST32.MER                                                    1  0x00016010            4    0    7    0    0   RO
+TEST32.IER                                                    1  0x00016004            4    0    7    0    0   RW
+TEST32.ISR                                                    1  0x00016008            4    0    7    0    0   RW
+TEST32.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT32:4
+
+# sie must be writeable
+TEST33.SIE                                                    1  0x0000F000            4    0    7    0    0   RO
+TEST33.CIE                                                    1  0x0001700C            4    0    7    0    0   RW
+TEST33.IER                                                    1  0x00017004            4    0    7    0    0   RW
+TEST33.ISR                                                    1  0x00017008            4    0    7    0    0   RW
+TEST33.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT33:4
+
+# cie must be writeable
+TEST34.SIE                                                    1  0x00018000            4    0    7    0    0   RW
+TEST34.CIE                                                    1  0x0001800C            4    0    7    0    0   RO
+TEST34.IER                                                    1  0x00018004            4    0    7    0    0   RW
+TEST34.ISR                                                    1  0x00018008            4    0    7    0    0   RW
+TEST34.DAQ_READY                                              0  0x00000000            0    0    0    0    0   INTERRUPT34:4
+


### PR DESCRIPTION
The GenericMuxedInterruptDistributor handles hierarchical interrupts on an interrupt controller and distributes them to the according to sub domain. The implementation was tested on the Xilinx AXI4 interrupt controller, but it is extensible to work with many types of interrupt controllers. 