### PR TITLE
fix(uio-backend): Add missing include

### DIFF
--- a/backends/uio/include/UioAccess.h
+++ b/backends/uio/include/UioAccess.h
@@ -5,6 +5,7 @@
 #include <boost/filesystem.hpp>
 
 #include <atomic>
+#include <memory>
 #include <string>
 
 namespace ChimeraTK {


### PR DESCRIPTION
For some reason this is necessary on Yocto master