### PR TITLE
improvement: acc.read throws if in ReadAnyGroup

### DIFF
--- a/include/TransferElement.h
+++ b/include/TransferElement.h
@@ -118,6 +118,10 @@ namespace ChimeraTK {
         throw ChimeraTK::logic_error("Calling read() or write() on the TransferElement '" + _name +
             "' which is part of a TransferGroup is not allowed.");
       }
+      if(TransferElement::_isInReadAnyGroup) {
+        throw ChimeraTK::logic_error("Directly calling read() on the TransferElement '" + _name +
+            "' which is part of a ReadAnyGroup is not allowed.");
+      }
       this->readTransactionInProgress = false;
 
       preReadAndHandleExceptions(TransferType::read);
@@ -143,6 +147,10 @@ namespace ChimeraTK {
       if(TransferElement::_isInTransferGroup) {
         throw ChimeraTK::logic_error("Calling read() or write() on the TransferElement '" + _name +
             "' which is part of a TransferGroup is not allowed.");
+      }
+      if(TransferElement::_isInReadAnyGroup) {
+        throw ChimeraTK::logic_error("Directly calling readNonBlocking() on the TransferElement '" + _name +
+            "' which is part of a ReadAnyGroup is not allowed.");
       }
       this->readTransactionInProgress = false;
       preReadAndHandleExceptions(TransferType::readNonBlocking);
@@ -819,6 +827,9 @@ namespace ChimeraTK {
     /** Flag whether this TransferElement has been added to a TransferGroup or not
      */
     bool _isInTransferGroup{false};
+
+    /** Flag whether this TransferElement has been added to a ReadAnyGroup or not*/
+    bool _isInReadAnyGroup{false};
 
     /** The access mode flags for this transfer element.*/
     AccessModeFlags _accessModeFlags;

--- a/include/TransferElementAbstractor.h
+++ b/include/TransferElementAbstractor.h
@@ -142,7 +142,7 @@ namespace ChimeraTK {
      *
      * Note: Avoid using this in application code, since it will break the abstraction!
      */
-    const boost::shared_ptr<TransferElement>& getHighLevelImplElement() { return _impl; }
+    [[nodiscard]] boost::shared_ptr<TransferElement>& getHighLevelImplElement() { return _impl; }
 
     /**
      * Return if the accessor is properly initialised. It is initialised if it was constructed passing the pointer to an

--- a/include/TransferGroup.h
+++ b/include/TransferGroup.h
@@ -17,11 +17,11 @@ namespace ChimeraTK {
    * Note that read() and write() of the accessors put into the group can no longer be used. Instead, read() and write()
    * of the TransferGroup should be called.
    *
-   * Important note: If accessors pointing to the same values are added to the TransferGroup, the behaviour will be when
-   * writing. Depending on the backend and on the exact scenario, the accessors might appear like a copy sharing the
-   * internal buffers, thus writing to one accessor may (or may not) change the content of the other. Also calling
-   * write() has then undefined behaviour, since it is not defined from which accessor the values will be written to the
-   * device (maybe both in an undefined order).
+   * Important note: If accessors pointing to the same values are added to the TransferGroup, the behaviour will be
+   * undefined when writing. Depending on the backend and on the exact scenario, the accessors might appear like a copy
+   * sharing the internal buffers, thus writing to one accessor may (or may not) change the content of the other. Also
+   * calling write() has then undefined behaviour, since it is not defined from which accessor the values will be
+   * written to the device (maybe both in an undefined order).
    */
   class TransferGroup {
    public:

--- a/tests/executables_src/testAsyncRead.cpp
+++ b/tests/executables_src/testAsyncRead.cpp
@@ -735,3 +735,27 @@ BOOST_AUTO_TEST_CASE(testReadAnyException) {
 }
 
 /**********************************************************************************************************************/
+
+BOOST_AUTO_TEST_CASE(testReadAnyInvalid) {
+  std::cout << "testReadAnyInvalid" << std::endl;
+
+  Device device;
+  device.open(cdd);
+  auto backend = boost::dynamic_pointer_cast<AsyncTestDummy>(BackendFactory::getInstance().createBackend(cdd));
+  BOOST_CHECK(backend != nullptr);
+
+  // obtain register accessor with integral type
+  auto a1 = device.getScalarRegisterAccessor<uint8_t>("a1", 0, {AccessMode::wait_for_new_data});
+
+  // Create ReadAnyGroup
+  ReadAnyGroup group{a1};
+
+  {
+    // direct read on accessor in ReadAnyGroup is not allowed and should issue exception.
+    BOOST_CHECK_THROW(a1.read(), ChimeraTK::logic_error);
+  }
+
+  device.close();
+}
+
+/**********************************************************************************************************************/


### PR DESCRIPTION
if the accessor is already in a ReadAnyGroup, that must be used for reading