### PR TITLE
fix(xdma): backend must not close itself on error

### DIFF
--- a/backends/xdma/src/XdmaBackend.cc
+++ b/backends/xdma/src/XdmaBackend.cc
@@ -23,10 +23,11 @@ namespace ChimeraTK {
       if(isFunctional()) {
         return;
       }
-      close();
     }
 
     _ctrlIntf.emplace(_devicePath);
+
+    std::for_each(_eventFiles.begin(), _eventFiles.end(), [](auto& eventFile) { eventFile = nullptr; });
 
     // Build vector of DMA channels
     _dmaChannels.clear();
@@ -50,10 +51,11 @@ namespace ChimeraTK {
     std::for_each(_eventFiles.begin(), _eventFiles.end(), [](auto& eventFile) { eventFile = nullptr; });
     _ctrlIntf.reset();
     _dmaChannels.clear();
+    _opened = false;
   }
 
   bool XdmaBackend::isOpen() {
-    return _ctrlIntf.has_value();
+    return _opened;
   }
 
   XdmaIntfAbstract& XdmaBackend::_intfFromBar(uint64_t bar) {


### PR DESCRIPTION
The XDMA backend called internally close() when a recovery of an
exception was attempted. In particular if the recovery was still
unsuccessful, the device was then left in the closed state leading to
logic_error exceptions in subsequent read/write operations. This caused
ApplicationCore applications to terminate immediately after an exception
of an XDMA device was seen.

This is now fixed by using a dedicated flag for the backend opened
status which is independent of the underlying interface status.