### PR TITLE
fix(sharedDummy): catch exception after previous instance interrupted

### DIFF
--- a/backends/SharedDummy/include/SharedDummyBackend.h
+++ b/backends/SharedDummy/include/SharedDummyBackend.h
@@ -155,7 +155,7 @@ namespace ChimeraTK {
     }; /* class SharedMemoryManager */
 
     // Managed shared memory object
-    SharedMemoryManager sharedMemoryManager;
+    std::unique_ptr<SharedMemoryManager> sharedMemoryManager;
 
     // Setup register bars in shared memory
     void setupBarContents();

--- a/backends/SharedDummy/src/SharedMemoryManager.cc
+++ b/backends/SharedDummy/src/SharedMemoryManager.cc
@@ -56,7 +56,7 @@ namespace ChimeraTK {
     {
       IpcNamedMutex proxy(interprocessMutex);
       std::unique_lock<IpcNamedMutex> lock(proxy, std::defer_lock);
-      auto ok = lock.try_lock_for(std::chrono::milliseconds(2000));
+      bool ok = lock.try_lock_for(std::chrono::milliseconds(2000));
       if(!ok) {
         std::cerr << "SharedDummyBackend: stale lock detected, removing mutex... " << std::endl;
 


### PR DESCRIPTION
The SharedDummy backend was crashing with a
boost::interprocess::lock_exception when a previous instance was
interrupted in the wrogn place. This is now fixed by catching the
exception and removing the shared memory segment (which is then broken
anyway).