### PR TITLE
fix(lmap): temporary fix for logic_errors in postRead with math plugin

### DIFF
--- a/backends/LogicalNameMapping/src/LNMMathPlugin.cc
+++ b/backends/LogicalNameMapping/src/LNMMathPlugin.cc
@@ -539,7 +539,7 @@ namespace ChimeraTK::LNMBackend {
     if(results.count() == 0) {
       // if results.count() is 0, the return statement presumably has not been used
       if(resultBuffer.size() != 1) {
-        throw ChimeraTK::logic_error("LogicalNameMapping MathPlugin for register '" + varName +
+        throw ChimeraTK::runtime_error("LogicalNameMapping MathPlugin for register '" + varName +
             "': The expression returns a scalar but " + std::to_string(resultBuffer.size()) + " expected.");
       }
       resultBuffer[0] = numericToUserType<T>(valueWhenNotUsingReturn);
@@ -550,14 +550,14 @@ namespace ChimeraTK::LNMBackend {
 
       // make sure we got a numeric result
       if(result.type != exprtk::type_store<double>::e_scalar && result.type != exprtk::type_store<double>::e_vector) {
-        throw ChimeraTK::logic_error("LogicalNameMapping MathPlugin for register '" + varName +
+        throw ChimeraTK::runtime_error("LogicalNameMapping MathPlugin for register '" + varName +
             "': The expression did not return a numeric result.");
       }
 
       // create vector view and check that its size matches
       exprtk::type_store<double>::type_view<double> view(result);
       if(view.size() != resultBuffer.size()) {
-        throw ChimeraTK::logic_error("LogicalNameMapping MathPlugin for register '" + varName +
+        throw ChimeraTK::runtime_error("LogicalNameMapping MathPlugin for register '" + varName +
             "': The expression returns " + std::to_string(view.size()) + " elements but " +
             std::to_string(resultBuffer.size()) + " expected.");
       }
@@ -569,7 +569,7 @@ namespace ChimeraTK::LNMBackend {
     }
     else {
       // multiple results in return statement are unexpected
-      throw ChimeraTK::logic_error("LogicalNameMapping MathPlugin for register '" + varName +
+      throw ChimeraTK::runtime_error("LogicalNameMapping MathPlugin for register '" + varName +
           "': The expression returned " + std::to_string(results.count()) + " results, expect exactly one result.");
     }
   }

--- a/tests/executables_src/testLMapMathPlugin.cpp
+++ b/tests/executables_src/testLMapMathPlugin.cpp
@@ -167,19 +167,19 @@ BOOST_AUTO_TEST_CASE(testExceptions) {
 
   auto acc1 = device.getOneDRegisterAccessor<double>("WrongReturnSizeInArray");
   BOOST_CHECK_THROW(acc1.read(), ChimeraTK::logic_error);
-  BOOST_CHECK_THROW(acc1.write(), ChimeraTK::logic_error);
+  BOOST_CHECK_THROW(acc1.write(), ChimeraTK::runtime_error);
 
   auto acc2 = device.getOneDRegisterAccessor<double>("ReturnScalarDespiteArray");
   BOOST_CHECK_THROW(acc2.read(), ChimeraTK::logic_error);
-  BOOST_CHECK_THROW(acc2.write(), ChimeraTK::logic_error);
+  BOOST_CHECK_THROW(acc2.write(), ChimeraTK::runtime_error);
 
   auto acc3 = device.getOneDRegisterAccessor<double>("ReturnString");
   BOOST_CHECK_THROW(acc3.read(), ChimeraTK::logic_error);
-  BOOST_CHECK_THROW(acc3.write(), ChimeraTK::logic_error);
+  BOOST_CHECK_THROW(acc3.write(), ChimeraTK::runtime_error);
 
   auto acc4 = device.getOneDRegisterAccessor<double>("ReturnMultipleValues");
   BOOST_CHECK_THROW(acc4.read(), ChimeraTK::logic_error);
-  BOOST_CHECK_THROW(acc4.write(), ChimeraTK::logic_error);
+  BOOST_CHECK_THROW(acc4.write(), ChimeraTK::runtime_error);
 }
 
 /**********************************************************************************************************************/


### PR DESCRIPTION
This creates rather annoying issues when used with a TransferGroup, in
which case the exception message is totally invisible ("terminate called
without an active exception").

A more permanent solution should execute checks when the formula is
compiled, so the logic_error can be thrown earlier.