### PR TITLE
chore: use BOOST_TEST for more diagnostics in one test

### DIFF
--- a/tests/executables_src/testSubdeviceBackend.cpp
+++ b/tests/executables_src/testSubdeviceBackend.cpp
@@ -638,7 +638,7 @@ BOOST_AUTO_TEST_CASE(testAreaHandshake1) {
     accS = 0;
     accS.write();
   }
-  BOOST_CHECK(countStatusResets == 8);
+  BOOST_TEST(countStatusResets == 8);
   t.join();
   accArea.read();
   BOOST_CHECK(accArea[0] == 1897);


### PR DESCRIPTION
This is an attempt to debug a spurious, hard to reproduce race
condition, which has been seen only on Jenkins so far.