### PR TITLE
fix: don't throw logic_error in TransferGroup directly (#14286)

### DIFF
--- a/doc/spec_TransferElement.dox
+++ b/doc/spec_TransferElement.dox
@@ -145,6 +145,7 @@ This document describes the behaviour of the TransferElement base class, the NDR
       - If wait_for_new_data is not set, it calls doReadTransferSynchrously() and returns true
     - \anchor transferElement_B_4_2_3 4.2.3 writeTransferYyy() calls the corresonding doWriteTransferYyy() [\ref testTransferElement_B_4_2_3 "T"]
     - \anchor transferElement_B_4_2_4 4.2.4 Transfer implementations do not change the application buffer [\ref UnifiedTest_TransferElement_B_4_2_4 "U"]
+    - \anchor transferElement_B_4_2_5 4.2.5 xxxTransferYyy() can be skipped between preXxx() and postXxx(), even if preXxx() has not thrown an exception. In this case, postXxx() must be called with the updateDataBuffer set to false. The result of such operation is no observable change, in particular the application buffer must remain unaltered. See \ref transferElement_B_12_10_2_3 "B.12.10.2.3".
   - \anchor transferElement_B_4_3 4.3 postXxx(): calls doPostXxx() of the implementation to allow follow-up work after the actual transfer. [\ref testTransferElement_B_4_3 "T"]
     - 4.3.1 In read transfers, doPostRead() is the only place where the application buffer may be changed (*).
     - \anchor transferElement_B_4_3_2 4.3.2 In write transfers, postWrite() updates the version number of the application buffer TransferElement::_versionNumber to the version number provided to the write() call, if no exception is (re-)thrown in doPostWrite() (cf. \ref transferElement_B_11_3 "B.11.3"). [\ref testTransferElement_B_4_3_2 "T"]
@@ -271,14 +272,11 @@ This document describes the behaviour of the TransferElement base class, the NDR
     - \anchor transferElement_B_12_9_2 12.9.2 next call the corresponding xxxTransferYyy() on all low-level elements (cf. \ref transferElement_B_12_1_2_2 "12.1.2.2"), and
     - \anchor transferElement_B_12_9_3 12.9.3 finally call postXxx() on all high-level elements.
   - 12.10 The TransferGroup implements a similar exception handling in TransferGroup::read() and TransferGroup::write() as their TransferElement counterparts. This especially means:
-    - \anchor transferElement_B_12_10_1 12.10.1 Before preXxx() is called, the TransferGroup checks all pre-conditions (device opened and operation allowed) to make sure no ChimeraTK::logic_error can occur.
-      - \anchor transferElement_B_12_10_1_1 12.10.1.1 If any ChimeraTK::runtime_error occurs while checking the pre-conditions, it is immediately passed on to the application. [\ref testTransferElement_B_12_10_1_1 "T"]
-      - \anchor transferElement_B_12_10_1_2 12.10.1.2 Any pre-condition which is not met will immediately result in a thrown ChimeraTK::logic_error [\ref testTransferElement_B_12_10_1_2 "T"]
-      - 12.10.1.3 The exceptions from \ref transferElement_B_12_10_1_1 "12.10.1.1" and \ref transferElement_B_12_10_1_2 "12.10.1.2" are not prioritised by type. The first detected error throws.
+    - \anchor transferElement_B_12_10_1 12.10.1 (removed)
     - \anchor transferElement_B_12_10_2 12.10.2 If ChimeraTK::runtime_error exceptions occur during preXxx()
       - \anchor transferElement_B_12_10_2_1 12.10.2.1 still all preXxx() are executed.
       - \anchor transferElement_B_12_10_2_2 12.10.2.2 the whole transfer phase is skipped.
-      - \anchor transferElement_B_12_10_2_3 12.10.2.3 This implies that TransferElements in TransferGroups must expect that the transfer is not executed, even if preXxx() has not thrown an exception.
+      - \anchor transferElement_B_12_10_2_3 12.10.2.3 This implies that TransferElements in TransferGroups must expect that the transfer is not executed, even if preXxx() has not thrown an exception. See \ref transferElement_B_4_2_5 "B.4.2.5".
     - \anchor transferElement_B_12_10_3 12.10.3 ChimeraTK::runtime_error exceptions thrown by the low-level elements are propagated to the corresponding high-level elements so they are seen by their postXxx() functions (c.f. \ref transferElement_B_6_3 "6.3") [\ref testTransferElement_B_12_10_3 "INCOMPLETE T"]
     - \anchor transferElement_B_12_10_4 12.10.4 postXxx() is called for all high level elements, even if some postXxx() throw exceptions (c.f. \ref transferElement_B_5 "5"). [\ref testTransferElement_B_12_10_4 "T"]
     - \anchor transferElement_B_12_10_5 12.10.5 The first exception that has been caught in \ref transferElement_B_12_9_1 "12.9.1", \ref transferElement_B_12_9_2 "12.9.2" or \ref transferElement_B_12_9_3 "12.9.3" is re-thrown. [\ref testTransferElement_B_12_10_5 "INCOMPLETE T"]

--- a/include/TransferGroup.h
+++ b/include/TransferGroup.h
@@ -79,12 +79,6 @@ namespace ChimeraTK {
     /** List of high-level TransferElements in this group which are directly used by the user */
     std::set<boost::shared_ptr<TransferElement>> _highLevelElements;
 
-    /**
-     * List of all exception backends. We check on them whether they are opened, and we want to do it for all accessors
-     * of the same backend just once.
-     */
-    std::set<boost::shared_ptr<DeviceBackend>> _exceptionBackends;
-
     /** Cached value whether all elements are readable. */
     bool _isReadable{false};
 
@@ -99,7 +93,7 @@ namespace ChimeraTK {
 
     // Helper function to avoid code duplication. Needs to be run for two lists.
     void runPostReads(const std::set<boost::shared_ptr<TransferElement>>& elements,
-        const std::exception_ptr& firstDetectedRuntimeError) noexcept;
+        const std::exception_ptr& firstDetectedRuntimeError);
 
     // Counter how many runtime errors have been thrown.
     size_t _nRuntimeErrors;

--- a/src/TransferGroup.cc
+++ b/src/TransferGroup.cc
@@ -15,7 +15,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   void TransferGroup::runPostReads(const std::set<boost::shared_ptr<TransferElement>>& elements,
-      const std::exception_ptr& firstDetectedRuntimeError) noexcept {
+      const std::exception_ptr& firstDetectedRuntimeError) {
     for(const auto& elem : elements) {
       // check for exceptions on any of the element's low level elements
       for(const auto& lowLevelElem : elem->getHardwareAccessingElements()) {
@@ -45,16 +45,6 @@ namespace ChimeraTK {
     // reset exception flags
     for(auto& it : _lowLevelElementsAndExceptionFlags) {
       it.second = false;
-    }
-
-    // check pre-conditions so preRead() does not throw logic errors
-    for(const auto& backend : _exceptionBackends) {
-      if(backend && !backend->isOpen()) {
-        throw ChimeraTK::logic_error("DeviceBackend " + backend->readDeviceInfo() + "is not opened!");
-      }
-    }
-    if(!isReadable()) {
-      throw ChimeraTK::logic_error("TransferGroup::read() called, but not all elements are readable.");
     }
 
     std::exception_ptr firstDetectedRuntimeError{nullptr};
@@ -121,16 +111,6 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   void TransferGroup::write(VersionNumber versionNumber) {
-    // check pre-conditions so preRead() does not throw logic errors
-    for(const auto& backend : _exceptionBackends) {
-      if(backend && !backend->isOpen()) {
-        throw ChimeraTK::logic_error("DeviceBackend " + backend->readDeviceInfo() + "is not opened!");
-      }
-    }
-    if(!isWriteable()) {
-      throw ChimeraTK::logic_error("TransferGroup::write() called, but not all elements are writeable.");
-    }
-
     for(auto& it : _lowLevelElementsAndExceptionFlags) {
       it.second = false;
     }
@@ -222,8 +202,6 @@ namespace ChimeraTK {
 
     // set flag on the accessors that it is now in a transfer group
     accessor.getHighLevelImplElement()->_isInTransferGroup = true;
-
-    _exceptionBackends.insert(accessor.getHighLevelImplElement()->getExceptionBackend());
 
     auto highLevelElementsWithNewAccessor = _highLevelElements;
     highLevelElementsWithNewAccessor.insert(accessor.getHighLevelImplElement());

--- a/tests/executables_src/testTransferGroup.cpp
+++ b/tests/executables_src/testTransferGroup.cpp
@@ -290,68 +290,6 @@ BOOST_AUTO_TEST_CASE(test_B_12_9) {
   CHECK_COUNTERS_LOW_LEVEL(B->_internalElements[0], false, 2, 4);
   CHECK_COUNTERS_LOW_LEVEL(B->_internalElements[1], false, 2, 4);
 }
-/**********************************************************************************************************************/
-
-/**
- *  Test runtime_error in precondition check
- *  * \anchor testTransferElement_B_12_10_1_1 \ref transferElement_B_12_10_1_1 "B.12.10.1.1"
- */
-BOOST_AUTO_TEST_CASE(test_B_12_10_1_1) {
-  std::cout << "test_B_12_10_1_1" << std::endl;
-  auto A = makeTETA();
-  A->_throwRuntimeErrInPreconditions = true;
-  TransferGroup group;
-  group.addAccessor(A);
-  BOOST_CHECK_THROW(group.read(), ChimeraTK::runtime_error);
-  BOOST_CHECK_THROW(group.write(), ChimeraTK::runtime_error);
-  BOOST_CHECK_EQUAL(A->_preRead_counter, 0);
-  BOOST_CHECK_EQUAL(A->_preWrite_counter, 0);
-  BOOST_CHECK_EQUAL(A->_readTransfer_counter, 0);
-  BOOST_CHECK_EQUAL(A->_writeTransfer_counter, 0);
-  BOOST_CHECK_EQUAL(A->_writeTransferDestructively_counter, 0);
-  BOOST_CHECK_EQUAL(A->_postRead_counter, 0);
-  BOOST_CHECK_EQUAL(A->_postWrite_counter, 0);
-}
-
-/**********************************************************************************************************************/
-
-/**
- *  Test that operation throws if precondition not met
- *  * \anchor testTransferElement_B_12_10_1_2 \ref transferElement_B_12_10_1_2 "B.12.10.1.2"
- */
-BOOST_AUTO_TEST_CASE(test_B_12_10_1_2) {
-  std::cout << "test_B_12_10_1_2" << std::endl;
-  {
-    auto A = makeTETA();
-    A->_readable = false;
-    TransferGroup group;
-    group.addAccessor(A);
-    BOOST_CHECK_THROW(group.read(), ChimeraTK::logic_error);
-    BOOST_CHECK_EQUAL(A->_preRead_counter, 0);
-    BOOST_CHECK_EQUAL(A->_preWrite_counter, 0);
-    BOOST_CHECK_EQUAL(A->_readTransfer_counter, 0);
-    BOOST_CHECK_EQUAL(A->_writeTransfer_counter, 0);
-    BOOST_CHECK_EQUAL(A->_writeTransferDestructively_counter, 0);
-    BOOST_CHECK_EQUAL(A->_postRead_counter, 0);
-    BOOST_CHECK_EQUAL(A->_postWrite_counter, 0);
-    BOOST_CHECK_NO_THROW(group.write());
-  }
-  {
-    auto A = makeTETA();
-    A->_writeable = false;
-    TransferGroup group;
-    group.addAccessor(A);
-    BOOST_CHECK_THROW(group.write(), ChimeraTK::logic_error);
-    BOOST_CHECK_EQUAL(A->_preRead_counter, 0);
-    BOOST_CHECK_EQUAL(A->_preWrite_counter, 0);
-    BOOST_CHECK_EQUAL(A->_readTransfer_counter, 0);
-    BOOST_CHECK_EQUAL(A->_writeTransfer_counter, 0);
-    BOOST_CHECK_EQUAL(A->_writeTransferDestructively_counter, 0);
-    BOOST_CHECK_EQUAL(A->_postRead_counter, 0);
-    BOOST_CHECK_EQUAL(A->_postWrite_counter, 0);
-    BOOST_CHECK_NO_THROW(group.read());
-  }
-}
 
 /**********************************************************************************************************************/
 

--- a/tests/include/TransferElementTestAccessor.h
+++ b/tests/include/TransferElementTestAccessor.h
@@ -27,6 +27,9 @@ namespace ChimeraTK {
       try {
         if(_throwLogicErr) throw ChimeraTK::logic_error("Test");
         if(_throwRuntimeErrInPre) throw ChimeraTK::runtime_error("Test");
+        if(!_readable) {
+          throw ChimeraTK::logic_error("Not readable!");
+        }
       }
       catch(...) {
         _thrownException = std::current_exception();
@@ -44,6 +47,9 @@ namespace ChimeraTK {
         if(_throwLogicErr) throw ChimeraTK::logic_error("Test");
         if(_throwRuntimeErrInPre) throw ChimeraTK::runtime_error("Test");
         if(_throwNumericCast) throw boost::numeric::bad_numeric_cast();
+        if(!_writeable) {
+          throw ChimeraTK::logic_error("Not writeable!");
+        }
       }
       catch(...) {
         _thrownException = std::current_exception();
@@ -148,20 +154,11 @@ namespace ChimeraTK {
       _listReplacementElements.push_back(newElement->getId());
     }
 
-    bool isReadOnly() const override {
-      if(_throwRuntimeErrInPreconditions) throw ChimeraTK::runtime_error("Test");
-      return !_writeable && _readable;
-    }
+    bool isReadOnly() const override { return !_writeable && _readable; }
 
-    bool isReadable() const override {
-      if(_throwRuntimeErrInPreconditions) throw ChimeraTK::runtime_error("Test");
-      return _readable;
-    }
+    bool isReadable() const override { return _readable; }
 
-    bool isWriteable() const override {
-      if(_throwRuntimeErrInPreconditions) throw ChimeraTK::runtime_error("Test");
-      return _writeable;
-    }
+    bool isWriteable() const override { return _writeable; }
 
     void interrupt() override { this->interrupt_impl(this->_readQueue); }
 
@@ -195,10 +192,9 @@ namespace ChimeraTK {
     bool _throwLogicErr{false};    // always in doPreXxx()
     bool _throwRuntimeErrInTransfer{false};
     bool _throwRuntimeErrInPre{false};
-    bool _throwRuntimeErrInPreconditions{false}; // throw in isReadable/isWriteable/isReadOnly
-    bool _throwNumericCast{false};               // in doPreWrite() or doPreRead() depending on operation
-    VersionNumber _setPostReadVersion{nullptr};  // if nullptr, a new version will be generated
-    UserType _setPostReadData{UserType()};       // data to be copied into the user buffer in postRead
+    bool _throwNumericCast{false};              // in doPreWrite() or doPreRead() depending on operation
+    VersionNumber _setPostReadVersion{nullptr}; // if nullptr, a new version will be generated
+    UserType _setPostReadData{UserType()};      // data to be copied into the user buffer in postRead
 
     // lists, counters etc. used for the TransferGroup tests
     std::list<TransferElementID> _listReplacementElements; // list of all arguments of replaceTransferElement()


### PR DESCRIPTION
This is no longer necessary, since the subsequent handling of all relevant exception types is appropriate also for logic_errors. It was also an issue, since in ApplicationCore the ExceptionHandlingDecorator prevents initiating transfers if the Device is temporarily closed while executing an init handler, but the TransferGroup throws the logic_error anyway.

This change comes with a spec change, since this was actually specified explicitly, and consequently tests for these spec points are removed as well.