### PR TITLE
fix: postRead in DataConsistencyDecorator

### DIFF
--- a/include/DataConsistencyGroupHistorizedMatcher.h
+++ b/include/DataConsistencyGroupHistorizedMatcher.h
@@ -45,7 +45,7 @@ namespace ChimeraTK::DataConsistencyGroupDetail {
     /// since after DiscardValueException, ReadAnyGroup does not call preRead at following operation,
     /// DataConsistencyDecorator must 'catch up' on preReads by calling this
     void handleMissingPreReads(TransferElementID callerId);
-    void handleMissingPostReads(TransferElementID callerId);
+    void handleMissingPostReads(TransferElementID callerId, bool updateBuffer);
 
     /// swap data of target buffer into history
     void updateHistory(TransferElementID transferElementID);

--- a/src/DataConsistencyDecorator.cc
+++ b/src/DataConsistencyDecorator.cc
@@ -34,7 +34,7 @@ namespace ChimeraTK {
     // we throw DiscardValueException. Assume then, we get another value for B, with version v3.
     // In this case, decorator(A) must not be swapped again, but decorator(B) should be swapped with target(B)=v3
     if(_hGroup->lastMatchingVersionNumber() > this->_versionNumber) {
-      _hGroup->handleMissingPostReads(this->getId());
+      _hGroup->handleMissingPostReads(this->getId(), updateDataBuffer);
     }
 
     // we overwrite implementation of base class NDRegisterAccessorDecorator because we
@@ -42,7 +42,7 @@ namespace ChimeraTK {
     // unless an exception originates from target->queue or its continuation(readCallback).
     if(this->_activeException) {
       _target->setActiveException(this->_activeException);
-      _target->postRead(type, updateDataBuffer);
+      _target->postRead(type, false);
     }
 
     // Decorators have to copy meta data even if updateDataBuffer is false

--- a/src/DataConsistencyGroupHistorizedMatcher.cc
+++ b/src/DataConsistencyGroupHistorizedMatcher.cc
@@ -89,7 +89,7 @@ namespace ChimeraTK::DataConsistencyGroupDetail {
 
   /********************************************************************************************************************/
 
-  void HistorizedMatcher::handleMissingPostReads(TransferElementID callerId) {
+  void HistorizedMatcher::handleMissingPostReads(TransferElementID callerId, bool updateBuffer) {
     // prevent recursion by setting flag
     if(_handleMissingPostReadsCalled) {
       return;
@@ -105,7 +105,7 @@ namespace ChimeraTK::DataConsistencyGroupDetail {
     for(auto& e : _pushElements) {
       if(e.first != callerId) {
         auto& acc = e.second;
-        acc.getHighLevelImplElement()->postRead(TransferType::read, true);
+        acc.getHighLevelImplElement()->postRead(TransferType::read, updateBuffer);
       }
     }
     _decoratorsNeedPreRead = true;


### PR DESCRIPTION
respect updateBuffer argument and do not update in case of exception

according to our recent discussion (with Martin H) we don't want to let postRead update data buffers in case of an exception. 
I did not perceive any bug or problem due to misbehavior. The only purpose of this change is to be in line with specification.