### PR TITLE
fix: shm dummy instance id hash

### DIFF
--- a/backends/SharedDummy/include/SharedDummyBackend.h
+++ b/backends/SharedDummy/include/SharedDummyBackend.h
@@ -46,8 +46,8 @@ namespace ChimeraTK {
    */
   class SharedDummyBackend : public DummyBackendBase {
    public:
-    SharedDummyBackend(const std::string& instanceId, const std::string& mapFileName,
-        const std::string& dataConsistencyKeyDescriptor = "");
+    SharedDummyBackend(
+        size_t instanceIdHash, const std::string& mapFileName, const std::string& dataConsistencyKeyDescriptor = "");
     ~SharedDummyBackend() override;
 
     void open() override;
@@ -87,7 +87,7 @@ namespace ChimeraTK {
       friend class SharedDummyBackend;
 
      public:
-      SharedMemoryManager(SharedDummyBackend&, const std::string&, const std::string&);
+      SharedMemoryManager(SharedDummyBackend&, std::size_t instanceIdHash, const std::string&);
       ~SharedMemoryManager();
 
       /**
@@ -113,11 +113,6 @@ namespace ChimeraTK {
       const char* SHARED_MEMORY_REQUIRED_VERSION_NAME = "RequiredVersion";
 
       SharedDummyBackend& sharedDummyBackend;
-
-      // Hashes to assure match of shared memory accessing processes
-      std::string userHash;
-      std::string mapFileHash;
-      std::string instanceIdHash;
 
       // the name of the segment
       std::string name;

--- a/backends/SharedDummy/src/SharedMemoryManager.cc
+++ b/backends/SharedDummy/src/SharedMemoryManager.cc
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "SharedDummyBackend.h"
+#include "Utilities.h"
 
 namespace ChimeraTK {
 
@@ -43,11 +44,8 @@ namespace ChimeraTK {
 
   // Construct/deconstruct
   SharedDummyBackend::SharedMemoryManager::SharedMemoryManager(
-      SharedDummyBackend& sharedDummyBackend_, const std::string& instanceId, const std::string& mapFileName)
-  : sharedDummyBackend(sharedDummyBackend_), userHash(std::to_string(std::hash<std::string>{}(getUserName()))),
-    mapFileHash(std::to_string(std::hash<std::string>{}(mapFileName))),
-    instanceIdHash(std::to_string(std::hash<std::string>{}(instanceId))),
-    name("ChimeraTK_SharedDummy_" + instanceIdHash + "_" + mapFileHash + "_" + userHash),
+      SharedDummyBackend& sharedDummyBackend_, std::size_t instanceIdHash, const std::string& mapFileName)
+  : sharedDummyBackend(sharedDummyBackend_), name(Utilities::createShmName(instanceIdHash, mapFileName, getUserName())),
     segment(boost::interprocess::open_or_create, name.c_str(), getRequiredMemoryWithOverhead()),
     sharedMemoryIntAllocator(segment.get_segment_manager()),
     interprocessMutex(boost::interprocess::open_or_create, name.c_str()) {

--- a/include/Utilities.h
+++ b/include/Utilities.h
@@ -64,6 +64,14 @@ namespace ChimeraTK {
      * name for dummies) */
     Sdm parseDeviceString(const std::string& deviceString);
 
+    /** Generates shm dummy instanceId hash from address and parameter map,
+     *  Intended for use with parseDeviceDesciptor return value. */
+    std::size_t shmDummyInstanceIdHash(
+        const std::string& address, const std::map<std::string, std::string>& parameters);
+
+    /** Generates shm dummy name from parameter hashes */
+    std::string createShmName(std::size_t instanceIdHash, const std::string& mapFileName, const std::string& userName);
+
     /** Check wehter the given string seems to be an SDM. There is no guarantee
      * that the SDM is well-formed, the finction just looks for the signatore of
      * an SDM. */

--- a/src/Utilities.cpp
+++ b/src/Utilities.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/filesystem.hpp>
 
 #include <cxxabi.h>
 #include <execinfo.h>
@@ -346,6 +347,31 @@ namespace ChimeraTK {
       std::string functionName = boost::core::demangle(msg.substr(a + 1, b - a - 1).c_str());
       std::cout << "[bt] #" << i << " " << functionName << std::endl;
     }
+  }
+
+/********************************************************************************************************************/
+
+  std::size_t Utilities::shmDummyInstanceIdHash(
+      const std::string& address, const std::map<std::string, std::string>& parameters) {
+    // To find hash, concatenate in ordered way, address and parameters
+    std::string str = address;
+    for(const auto& e : parameters) {
+      str += e.first + "=" + e.second + ";";
+    }
+    return std::hash<std::string>{}(str);
+  }
+
+/********************************************************************************************************************/
+
+  std::string Utilities::createShmName(
+      std::size_t instanceIdHash, const std::string& mapFileName, const std::string& userName) {
+    // always use absolute mapFileName
+    boost::filesystem::path absPathToMapFile = boost::filesystem::absolute(mapFileName);
+
+    std::string mapFileHash{std::to_string(std::hash<std::string>{}(absPathToMapFile.string()))};
+    std::string userHash{std::to_string(std::hash<std::string>{}(userName))};
+
+    return "ChimeraTK_SharedDummy_" + std::to_string(instanceIdHash) + "_" + mapFileHash + "_" + userHash;
   }
 
   /********************************************************************************************************************/

--- a/tests/executables_src/testSharedDummyBackendUnified.cpp
+++ b/tests/executables_src/testSharedDummyBackendUnified.cpp
@@ -24,6 +24,9 @@ BOOST_AUTO_TEST_SUITE(SharedDummyBackendUnifiedTestSuite)
 //  Use hardcoded information from the dmap-file
 static std::string instanceId{"1"};
 static std::string mapFileName{"sharedDummyUnified.map"};
+static std::size_t instanceIdHash = Utilities::shmDummyInstanceIdHash(instanceId, {{"map", mapFileName}});
+static std::string shmName{Utilities::createShmName(instanceIdHash, mapFileName, getUserName())};
+
 static std::string cdd(std::string("(sharedMemoryDummy:") + instanceId + "?map=" + mapFileName + ")");
 static boost::shared_ptr<SharedDummyBackend> sharedDummy;
 const int timeOutForWaitOnHelperProcess_ms = 20000;
@@ -263,9 +266,6 @@ BOOST_AUTO_TEST_CASE(TestVerifyMemoryDeleted) {
   // also clear our backend instance. This should also remove allocated SHM segments and semaphores
   // - note, this only works if the global instance map uses weak pointers
   sharedDummy.reset();
-
-  boost::filesystem::path absPathToMapFile = boost::filesystem::absolute(mapFileName);
-  std::string shmName{createExpectedShmName(instanceId, absPathToMapFile.string(), getUserName())};
 
   // Check that memory is removed
   bool shm_removed{false};

--- a/tests/include/sharedDummyHelpers.h
+++ b/tests/include/sharedDummyHelpers.h
@@ -12,15 +12,6 @@
 
 enum class MirrorRequestType : int { from = 1, to, stop };
 
-// Static helper functions
-std::string createExpectedShmName(std::string instanceId_, std::string mapFileName_, std::string userName) {
-  std::string mapFileHash{std::to_string(std::hash<std::string>{}(mapFileName_))};
-  std::string instanceIdHash{std::to_string(std::hash<std::string>{}(instanceId_))};
-  std::string userHash{std::to_string(std::hash<std::string>{}(userName))};
-
-  return "ChimeraTK_SharedDummy_" + instanceIdHash + "_" + mapFileHash + "_" + userHash;
-}
-
 bool shm_exists(std::string shmName) {
   bool result;
 

--- a/tests/unitTestsNotUnderCtest/testSharedDummyBackendExt.cpp
+++ b/tests/unitTestsNotUnderCtest/testSharedDummyBackendExt.cpp
@@ -20,7 +20,6 @@
 #include <cstdlib>
 #include <string>
 #include <thread>
-#include <utility>
 #include <vector>
 
 namespace {
@@ -32,12 +31,12 @@ namespace {
   static void interrupt_handler(int);
 
   // Static variables
-  //  Use hardcoded information from the dmap-file to
-  //  only use public interface here
-  static std::string instanceId{"1"};
-  static std::string mapFileName{"shareddummy.map"};
+  //  Use hardcoded information from the shareddummyTest.dmap to only use public interface here.
+  std::string mapFileName{"shareddummy.map"};
+  std::size_t instanceIdHash = Utilities::shmDummyInstanceIdHash("1", {{"map", mapFileName}});
+  std::string shmName{Utilities::createShmName(instanceIdHash, mapFileName, getUserName())};
 
-  static bool terminationCaught = false;
+  bool terminationCaught = false;
 
   BOOST_AUTO_TEST_SUITE(SharedDummyBackendTestSuite)
 
@@ -143,10 +142,6 @@ namespace {
     }
 
     setDMapFilePath("shareddummyTest.dmap");
-
-    boost::filesystem::path absPathToMapFile = boost::filesystem::absolute(mapFileName);
-
-    std::string shmName{createExpectedShmName(instanceId, absPathToMapFile.string(), getUserName())};
 
     {
       Device dev;
@@ -254,10 +249,6 @@ namespace {
    */
   BOOST_AUTO_TEST_CASE(testVerifyMemoryDeleted) {
     setDMapFilePath("shareddummyTest.dmap");
-
-    boost::filesystem::path absPathToMapFile = boost::filesystem::absolute(mapFileName);
-
-    std::string shmName{createExpectedShmName(instanceId, absPathToMapFile.string(), getUserName())};
 
     // Test if memory is removed
     BOOST_CHECK(!shm_exists(shmName));

--- a/tests/unitTestsNotUnderCtest/testSharedDummyBackendUnifiedExt.cpp
+++ b/tests/unitTestsNotUnderCtest/testSharedDummyBackendUnifiedExt.cpp
@@ -14,9 +14,7 @@
 
 #include <unistd.h>
 
-#include <algorithm>
 #include <string>
-#include <thread>
 
 namespace {
 
@@ -24,10 +22,10 @@ namespace {
   using namespace boost::unit_test_framework;
 
   // Static variables
-  //  Use hardcoded information from the dmap-file to
-  //  only use public interface here
-  static std::string instanceId{"1"};
-  static std::string mapFileName{"sharedDummyUnified.map"};
+  //  Use hardcoded information from sharedDummyUnified.dmap to only use public interface here.
+  std::string mapFileName{"sharedDummyUnified.map"};
+  std::size_t instanceIdHash = Utilities::shmDummyInstanceIdHash("1", {{"map", mapFileName}});
+  std::string shmName{Utilities::createShmName(instanceIdHash, mapFileName, getUserName())};
 
   BOOST_AUTO_TEST_SUITE(SharedDummyBackendUnifiedTestSuite)
 
@@ -59,9 +57,6 @@ namespace {
     bool keepRunning = true;
 
     setDMapFilePath("sharedDummyUnified.dmap");
-
-    boost::filesystem::path absPathToMapFile = boost::filesystem::absolute(mapFileName);
-    std::string shmName{createExpectedShmName(instanceId, absPathToMapFile.string(), getUserName())};
 
     {
       Device dev;


### PR DESCRIPTION
generate hash from address and all cdd parameters, even when unused. Like this, different cdds result in different shm instances. Put shm segment name creation to Utilities so its available for test code.

NOTE: This change breaks compatibility for shm dummy communication with previous DeviceAccess versions.