### PR TITLE
feat(lmap): Convenience plugins for system tags

### DIFF
--- a/backends/LogicalNameMapping/include/LNMAccessorPlugin.h
+++ b/backends/LogicalNameMapping/include/LNMAccessorPlugin.h
@@ -277,6 +277,18 @@ namespace ChimeraTK::LNMBackend {
     std::set<std::string> _tagsToSet;
   };
 
+  template<auto Tag>
+  class FixedTagModifierPlugin : public TagModifierPlugin {
+   public:
+    FixedTagModifierPlugin(const LNMBackendRegisterInfo& info, size_t pluginIndex,
+        [[maybe_unused]] const std::map<std::string, std::string>& parameters)
+    : TagModifierPlugin(info, pluginIndex, {{"add", Tag}}) {}
+
+    using TagModifierPlugin::doRegisterInfoUpdate;
+  };
+
+  /********************************************************************************************************************/
+
   /********************************************************************************************************************/
   /* Implementations follow here                                                                                      */
   /********************************************************************************************************************/

--- a/backends/LogicalNameMapping/src/LNMAccessorPlugin.cc
+++ b/backends/LogicalNameMapping/src/LNMAccessorPlugin.cc
@@ -4,6 +4,7 @@
 #include "LNMBackendRegisterInfo.h"
 #include "LNMDoubleBufferPlugin.h"
 #include "LNMMathPlugin.h"
+#include "SystemTags.h"
 
 #include <boost/make_shared.hpp>
 
@@ -39,6 +40,14 @@ namespace ChimeraTK::LNMBackend {
     }
     if(name == "tagModifier") {
       return boost::make_shared<TagModifierPlugin>(info, pluginIndex, parameters);
+    }
+    if(name == "isStatusOutput") {
+      return boost::make_shared<FixedTagModifierPlugin<ChimeraTK::SystemTags::statusOutput>>(
+          info, pluginIndex, parameters);
+    }
+    if(name == "hasReverseRecovery") {
+      return boost::make_shared<FixedTagModifierPlugin<ChimeraTK::SystemTags::reverseRecovery>>(
+          info, pluginIndex, parameters);
     }
     throw ChimeraTK::logic_error("LogicalNameMappingBackend: Unknown plugin type '" + name + "'.");
   }

--- a/backends/LogicalNameMapping/src/LNMTagModifierPluign.cc
+++ b/backends/LogicalNameMapping/src/LNMTagModifierPluign.cc
@@ -4,6 +4,7 @@
 #include "Exception.h"
 #include "LNMAccessorPlugin.h"
 #include "LNMBackendRegisterInfo.h"
+#include "SystemTags.h"
 
 #include <regex>
 
@@ -49,4 +50,5 @@ namespace ChimeraTK::LNMBackend {
       _info.tags = _tagsToSet;
     }
   }
+
 } // namespace ChimeraTK::LNMBackend

--- a/doc/logicalNameMapper.dox
+++ b/doc/logicalNameMapper.dox
@@ -85,6 +85,16 @@ Example with most features:
         <parameter name="set">status-output</parameter>
       </plugin>
     </redirectRegister>
+    <redirectedRegister name="StatusOutput">
+      <targetDevice>PCIE2</targetDevice>
+      <targetRegister>BOARD.WORD_STATUS</targetRegister>
+      <plugin name="isStatusOutput" />
+    </redirectedRegister>
+    <redirectedRegister name="PositionSetpoint">
+      <targetDevice>PCIE2</targetDevice>
+      <targetRegister>BOARD.POSITION_SETPOINT</targetRegister>
+      <plugin name="hasReverseRecovery" />
+    </redirectedRegister>
 </logicalNameMap>
 \endcode
 
@@ -327,4 +337,13 @@ Notes:
 - The plugin accepts either <code>add</code> and <code>remove</code> or <code>set</code>, but not a mix.
 - The order of application is first <code>add</code>, then <code>remove</code>.
 - See ChimeraTK::SystemTags for a list of pre-defined tags.
+
+\subsection plugins_reference_is_status_output isStatusOutput
+
+<code>isStatusOutput</code> is a plugin that will mark a register as being compatible with the StatusOutput expectations from ApplicationCore.
+
+\subsection plugins_reference_is_reverse_recovery hasReverseRecovery
+
+<code>hasReverseRecovery</code> is a plugin that will mark a register as not being written to on device start-up,
+ and potentially will be read instead.
 */

--- a/include/SystemTags.h
+++ b/include/SystemTags.h
@@ -17,13 +17,15 @@ namespace ChimeraTK {
    */
   struct SystemTags {
     /// Used to mark something as aggregable by ApplicationCore's status aggregator.
-    static constexpr auto statusOutput{"_ChimeraTK_StatusOutput_statusOutput"};
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+    static constexpr char statusOutput[]{"_ChimeraTK_StatusOutput_statusOutput"};
 
     /**
      * Used to flag a register as "reverse recovery". ApplicationCore can use this
      * information to not write into this register on device recovery, but pull the
      * latest value from it instead. Can also be used on write-only registers.
      */
-    static constexpr auto reverseRecovery{"_ChimeraTK_DeviceRegister_reverseRecovery"};
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+    static constexpr char reverseRecovery[]{"_ChimeraTK_DeviceRegister_reverseRecovery"};
   };
 } // namespace ChimeraTK

--- a/tests/executables_src/testLMapTagModifier.cc
+++ b/tests/executables_src/testLMapTagModifier.cc
@@ -8,6 +8,7 @@
 using namespace boost::unit_test_framework;
 
 #include "Device.h"
+#include "SystemTags.h"
 
 #include <iostream>
 
@@ -91,4 +92,20 @@ BOOST_AUTO_TEST_CASE(testRemove) {
 
   std::set<std::string> reference = {"main", "test"};
   BOOST_TEST(info.getTags() == reference, boost::test_tools::per_element());
+}
+
+BOOST_AUTO_TEST_CASE(testConvenienceTags) {
+  std::cout << "testConveniencePlugins" << std::endl;
+
+  ChimeraTK::Device device;
+
+  device.open("(logicalNameMap?map=tagModifierPlugin.xlmap)");
+  auto cat = device.getRegisterCatalogue();
+  auto baseInfo = cat.getRegister("convenienceReverse");
+  auto baseTagsReference = std::set<std::string>({ChimeraTK::SystemTags::reverseRecovery});
+  BOOST_TEST(baseInfo.getTags() == baseTagsReference, boost::test_tools::per_element());
+
+  baseInfo = cat.getRegister("convenienceStatusOutput");
+  baseTagsReference = std::set<std::string>({ChimeraTK::SystemTags::statusOutput});
+  BOOST_TEST(baseInfo.getTags() == baseTagsReference, boost::test_tools::per_element());
 }

--- a/tests/tagModifierPlugin.xlmap
+++ b/tests/tagModifierPlugin.xlmap
@@ -48,4 +48,16 @@
     </plugin>
   </redirectedRegister>
 
+  <redirectedRegister name="convenienceReverse">
+    <targetDevice>this</targetDevice>
+    <targetRegister>plain</targetRegister>
+    <plugin name="hasReverseRecovery" />
+  </redirectedRegister>
+
+  <redirectedRegister name="convenienceStatusOutput">
+    <targetDevice>this</targetDevice>
+    <targetRegister>plain</targetRegister>
+    <plugin name="isStatusOutput" />
+  </redirectedRegister>
+
 </logicalNameMap>


### PR DESCRIPTION
Add isStatusOutput and hasReverseRecovery plugins as a more condensed
way to add well-known ChimeraTK tags to registers
