### PR TITLE
fix: Do noting in CopyRegisterDecorator::doPreRead

### DIFF
--- a/include/CopyRegisterDecorator.h
+++ b/include/CopyRegisterDecorator.h
@@ -30,6 +30,11 @@ namespace ChimeraTK {
       }
     }
 
+    void doPreRead(TransferType) override {
+      // Do nothing. This should only ever be called from the TransferGroup which has already handled
+      // the preRead differently
+    }
+
     void doPreWrite(TransferType, VersionNumber) override {
       throw ChimeraTK::logic_error("ChimeraTK::CopyRegisterDecorator: Accessor is not writeable.");
     }
@@ -39,6 +44,11 @@ namespace ChimeraTK {
       if(hasNewData) {
         for(size_t i = 0; i < _target->getNumberOfChannels(); ++i) buffer_2D[i] = _target->accessChannel(i);
       }
+    }
+
+    void doReadTransferSynchronously() {
+      std::cerr << "CopyRegisterDecorator::doReadTransferSynchronously: Must not be called" << std::endl;
+      assert(false);
     }
 
     [[nodiscard]] bool isReadOnly() const override { return true; }

--- a/src/TransferGroup.cc
+++ b/src/TransferGroup.cc
@@ -56,6 +56,9 @@ namespace ChimeraTK {
       }
     }
 
+    // Call preRead on the copy decorators so that we can call postRead later with
+    // readTransactionInProgress flag set to true and do the actual copying in the
+    // decorator's doPostRead
     for(const auto& elem : _copyDecorators) {
       elem->preReadAndHandleExceptions(TransferType::read);
       if((elem->_activeException != nullptr) && (firstDetectedRuntimeError == nullptr)) {


### PR DESCRIPTION
The accessor should only ever be used in TransferGroup and that does
handle preRead of the target itself.

Also add an assertion such that a read transfer on the decorator does
not occur
