### PR TITLE
fix: userTypeToUserType with 0x

### DIFF
--- a/include/SupportedUserTypes.h
+++ b/include/SupportedUserTypes.h
@@ -303,7 +303,7 @@ namespace ChimeraTK {
     bool isHexidecimal = (value.length() > 1) and ((value[1] == 'x') or (value[1] == 'X')) and (value[0] == '0');
 
     if constexpr(!std::is_same<NUMERIC, int8_t>::value && !std::is_same<NUMERIC, uint8_t>::value) {
-      NUMERIC v;
+      NUMERIC v = 0;
       std::stringstream ss;
       if(isHexidecimal) {
         ss << std::hex << value.substr(2);


### PR DESCRIPTION
In userTypeToNumeric_impl<std::string, NUMERIC>::impl, NUMERIC v had been left uninitialized. This relied on v being initialized to 0, which doesn't work on Bookworm-release, causing the function to fail. Now it's explicitly initialized to 0.
This should solve error seen on [Jenkins](https://jenkins-sw.msktools.desy.de/job/Dragon%20Nightly%20Reporters/job/ChimeraTK-DeviceAccess-CommandBasedBackend/405/testReport/projectroot/tests/Generate_report___bookworm_release___bookworm_release_testStringUtils/). 