### PR TITLE
doc: Fix link to API in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The ChimeraTK DeviceAccess library provides an abstract interface for register based devices. Registers are identified by a name and usually accessed though an accessor object. Since this library also allows access to other control system applications, it can be understood as the client library of the ChimeraTK framework.
 
 The API documentation and tutorial examples for all versions are available under<br>
-<a href="https://chimeratk.github.io/DeviceAccess/index.html" target="_blank">https://chimeratk.github.io/DeviceAccess/index.html</a>
+<a href="https://chimeratk.github.io/ChimeraTK-DeviceAccess/head/html" target="_blank">https://chimeratk.github.io/ChimeraTK-DeviceAccess/head/html</a>
 
 ## Dependencies
 


### PR DESCRIPTION
Fixes the link to the api docs in the README.md file as it is currently broken (404). I linked the `head` version as also seen in https://github.com/ChimeraTK/DeviceAccess-PythonBindings