### PR TITLE
fix(RebotBackend): Race condition when closing the connection.

### DIFF
--- a/backends/Rebot/src/Connection.cc
+++ b/backends/Rebot/src/Connection.cc
@@ -48,6 +48,12 @@ namespace ChimeraTK::Rebot {
   }
 
   void Connection::close() {
+    std::unique_lock lock{_closeMutex, std::defer_lock};
+    if(!lock.try_lock()) {
+      // Mutex already taken! Another thread is handling the close. Returning immediately.
+      return;
+    }
+
     if(s_.is_open()) {
       s_.cancel();
       s_.shutdown(boost::asio::ip::tcp::socket::shutdown_both);

--- a/backends/Rebot/src/Connection.h
+++ b/backends/Rebot/src/Connection.h
@@ -45,6 +45,8 @@ namespace ChimeraTK::Rebot {
     boost::asio::deadline_timer disconnectTimer_;
     boost::asio::deadline_timer::duration_type connectionTimeout_;
 
+    std::mutex _closeMutex; // prevent concurrent close from the backend and the connection timeout
+
     void disconnectionTimerStart();
     void disconnectionTimerCancel(const boost::system::error_code& ec);
   };


### PR DESCRIPTION
The backend itself and the asio timeout thread are both closing the backend.
If it happened simultaneously, one of them would throw an expection doe to a
half closed socket.
