### PR TITLE
(uio-backend): Add support for device tree node names

### DIFF
--- a/backends/uio/include/UioAccess.h
+++ b/backends/uio/include/UioAccess.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <atomic>
 #include <memory>
@@ -12,7 +12,7 @@ namespace ChimeraTK {
   /// @brief Implements a generic userspace interface for UIO devices.
   class UioAccess {
    private:
-    boost::filesystem::path _deviceFilePath;
+    std::filesystem::path _deviceFilePath;
     int _deviceFileDescriptor = 0;
     void* _deviceUserBase = nullptr;
     void* _deviceKernelBase = nullptr;

--- a/backends/uio/include/UioAccess.h
+++ b/backends/uio/include/UioAccess.h
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #pragma once
 
-#include <filesystem>
-
 #include <atomic>
+#include <filesystem>
 #include <memory>
 #include <string>
 
@@ -25,6 +24,11 @@ namespace ChimeraTK {
 
     /// @brief Unmaps user space memory range for address range of UIO device.
     void UioUnmap();
+
+    /// @brief Looks up UIO device file name (e.g. uio0) from device tree node name.
+    /// @param dtNodeName Device tree node name
+    /// @return UIO device file name or empty string
+    static std::string lookupUioDevFromDtNode(const std::string dtNodeNname);
 
     /// @brief Subtracts uint32_t values taking overflow into account.
     /// @param minuend Minuend of subtraction

--- a/backends/uio/src/UioAccess.cc
+++ b/backends/uio/src/UioAccess.cc
@@ -23,11 +23,34 @@ namespace ChimeraTK {
     close();
   }
 
+  std::string UioAccess::lookupUioDevFromDtNode(const std::string dtNodeNname) {
+    std::string path = "/sys/class/uio/";
+    for(const auto& entry : std::filesystem::directory_iterator(path)) {
+      std::ifstream ifs{entry.path() / "name"};
+      if(!ifs) {
+        continue;
+      }
+
+      std::string currentName;
+      ifs >> currentName;
+      if(currentName == dtNodeNname) {
+        return entry.path().filename();
+      }
+    }
+    return "";
+  }
+
   void UioAccess::open() {
     if(std::filesystem::is_symlink(_deviceFilePath)) {
       _deviceFilePath = std::filesystem::canonical(_deviceFilePath);
     }
     std::string fileName = _deviceFilePath.filename().string();
+    std::string resolvedUioDev = lookupUioDevFromDtNode(fileName);
+    if(!resolvedUioDev.empty()) {
+      fileName = resolvedUioDev;
+      _deviceFilePath = "/dev/" + fileName;
+    }
+
     _deviceKernelBase = (void*)readUint64HexFromFile("/sys/class/uio/" + fileName + "/maps/map0/addr");
     _deviceMemSize = readUint64HexFromFile("/sys/class/uio/" + fileName + "/maps/map0/size");
     _lastInterruptCount = readUint32FromFile("/sys/class/uio/" + fileName + "/event");

--- a/backends/uio/src/UioAccess.cc
+++ b/backends/uio/src/UioAccess.cc
@@ -23,8 +23,8 @@ namespace ChimeraTK {
   }
 
   void UioAccess::open() {
-    if(boost::filesystem::is_symlink(_deviceFilePath)) {
-      _deviceFilePath = boost::filesystem::canonical(_deviceFilePath);
+    if(std::filesystem::is_symlink(_deviceFilePath)) {
+      _deviceFilePath = std::filesystem::canonical(_deviceFilePath);
     }
     std::string fileName = _deviceFilePath.filename().string();
     _deviceKernelBase = (void*)readUint64HexFromFile("/sys/class/uio/" + fileName + "/maps/map0/addr");

--- a/backends/uio/src/UioAccess.cc
+++ b/backends/uio/src/UioAccess.cc
@@ -11,6 +11,7 @@
 #include <poll.h>
 
 #include <cerrno>
+#include <cstring>
 #include <fstream>
 #include <limits>
 


### PR DESCRIPTION
Currently the plain device file name (e.g. `uio5` for `/dev/uio5`) must be given in the `.dmap` file. This is problematic, because that name is not only non-descriptive/unintuitive, but also unpredictable.

Consider following UIO setup:
```
$ lsuio
uio6: name=pl_ddr, version=devicetree, events=0
uio5: name=pl_app, version=devicetree, events=0
        map[0]: addr=0xA5000000, size=65536
uio4: name=axi_bram_ctrl, version=devicetree, events=0
        map[0]: addr=0xA4000000, size=2097152
uio3: name=axi-pmon, version=1.0, events=0
        map[0]: addr=0xFFA10000, size=65536
        map[1]: addr=0x01A9D000, size=4096
uio2: name=axi-pmon, version=1.0, events=0
        map[0]: addr=0xFD490000, size=65536
        map[1]: addr=0x01A9F000, size=4096
uio1: name=axi-pmon, version=1.0, events=0
        map[0]: addr=0xFD0B0000, size=65536
        map[1]: addr=0x01AA7000, size=4096
uio0: name=axi-pmon, version=1.0, events=0
        map[0]: addr=0xFFA00000, size=65536
        map[1]: addr=0x01AAC000, size=4096
```

in this case, the `pl_app` node is spawned as `uio5` but this depends on the presence of the `axi-pmon` nodes (`uio0..3`) and the order in which the kernel spawns `axi_bram_ctrl`, `pl_app` and `pl_ddr`.

It would be safer (and more descriptive/intuitive) to address the UIO nodes by their device tree node name (e.g. `pl_app`). This PR implements that and falls back to the old behavior (for backward compatibility) if none is found.

Example for UIO node declaration in device tree:
```
    pl_app: pl_app@a5000000 {
        compatible = "generic-uio";
        reg = <0x00 0xa5000000 0x00 0x10000>;
    };
```