### PR TITLE
fix(uio-backend): Add missing unistd include for close

### DIFF
--- a/backends/uio/src/UioAccess.cc
+++ b/backends/uio/src/UioAccess.cc
@@ -9,6 +9,7 @@
 
 #include <fcntl.h>
 #include <poll.h>
+#include <unistd.h>
 
 #include <cerrno>
 #include <cstring>


### PR DESCRIPTION
[Why]
When compiled with GCC 16.1.y, we receive the following compiler error:
> DeviceAccess/backends/uio/src/UioAccess.cc: In member function ‘void ChimeraTK::UioAccess::close()’:
> DeviceAccess/backends/uio/src/UioAccess.cc:71:9: error: ‘::close’ has not been declared; did you mean ‘pclose’?
>    71 |       ::close(_deviceFileDescriptor);
>       |         ^~~~~
>       |         pclose
> DeviceAccess/backends/uio/src/UioAccess.cc: In member function ‘uint32_t ChimeraTK::UioAccess::waitForInterrupt(int)’:
> DeviceAccess/backends/uio/src/UioAccess.cc:128:15: error: ‘::read’ has not been declared; did you mean ‘fread’?
>   128 |       ret = ::read(_deviceFileDescriptor, &totalInterruptCount, sizeof(totalInterruptCount));
>       |               ^~~~
>       |               fread
> DeviceAccess/backends/uio/src/UioAccess.cc: In member function ‘void ChimeraTK::UioAccess::clearInterrupts()’:
> DeviceAccess/backends/uio/src/UioAccess.cc:150:21: error: ‘::write’ has not been declared; did you mean ‘fwrite’?
>   150 |     ssize_t ret = ::write(_deviceFileDescriptor, &unmask, sizeof(unmask));
>       |                     ^~~~~
>       |                     fwrite
> DeviceAccess/backends/uio/src/UioAccess.cc: In member function ‘void ChimeraTK::UioAccess::UioMMap()’:
> DeviceAccess/backends/uio/src/UioAccess.cc:164:9: error: ‘::close’ has not been declared; did you mean ‘pclose’?
>   164 |       ::close(_deviceFileDescriptor);
>       |         ^~~~~
>       |         pclose

[How]
The open sys-call is defined in fcntl.h, but close is defined in
unistd.h.

Signed-off-by: Soeren Grunewald <soeren.grunewald@desy.de>
