### PR TITLE
fix: Support "staged" replacement of shared target

### DIFF
--- a/src/SharedAccessor.cc
+++ b/src/SharedAccessor.cc
@@ -14,9 +14,14 @@ namespace ChimeraTK::detail {
     auto newIter = _transferSharedStates.find(newId);
     assert(newIter != _transferSharedStates.end());
 
-    // The only action at the moment: sum the instance counts of both states
-    newIter->second.instanceCount = newIter->second.instanceCount + oldIter->second.instanceCount;
-    _transferSharedStates.erase(oldIter);
+    // Shift instanceCount from old to new. When old is no longer used after the shifting,
+    // drop the old entry
+    assert(oldIter->second.instanceCount >= 1);
+    --(oldIter->second.instanceCount);
+    ++(newIter->second.instanceCount);
+    if(oldIter->second.instanceCount == 0) {
+      _transferSharedStates.erase(oldIter);
+    }
   }
 
   /********************************************************************************************************************/


### PR DESCRIPTION
Situation:

- Accessor A with Target T1 created
- Accessor B with Target T2 created
- T1 is replaced with T2
- Accessor C with Target T3 created
- T2 is replaced with T3

 -> Previously, the assertion would trigger because replacing T2 in B
 would remove it from the map.